### PR TITLE
Wrap SIMD booleans into Simd<_>

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - run:
           name: install xargo
-          command: cargo install -f xargo;
+          command: rustup component add rust-src; cargo install -f xargo;
       - run:
           name: build
           command: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           name: build
           command: cargo web build --verbose --target wasm32-unknown-unknown;
   build-no-std:
-    executor: rust-executor
+    executor: rust-nightly-executor
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ default = [ "std" ]
 std = [ ]
 partial_fixed_point_support = [ "fixed", "cordic" ]
 serde_serialize = [ "serde", "fixed/serde" ]
+libm = [ "num-traits/libm" ]
 
 [dependencies]
-num-traits  = { version = "0.2.11", default-features = false, features = ["libm"] }
+num-traits  = { version = "0.2.11", default-features = false }
 approx      = { version = "0.3", default-features = false }
 decimal     = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.2", default-features = false }
@@ -28,6 +29,7 @@ cordic      = { version = "0.1", optional = true }
 paste       = "0.1"
 rand        = { version = "0.7", optional = true }
 serde       = { version = "1", default-features = false, optional = true }
+libm_force  = { package = "libm", version = "0.2", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ num-traits  = { version = "0.2.11", default-features = false, features = ["libm"
 approx      = { version = "0.3", default-features = false }
 decimal     = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.2", default-features = false }
-packed_simd = { version = "0.3", optional = true }
+packed_simd = { version = "0.3", features = [ "into_bits" ], optional = true }
 wide        = { version = "0.4", optional = true }
 fixed       = { version = "1", optional = true }
 cordic      = { version = "0.1", optional = true }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
-unstable_features = true
-indent_style = "Block"
-where_single_line = true
+# unstable_features = true
+# indent_style = "Block"
+# where_single_line = true

--- a/src/scalar/complex.rs
+++ b/src/scalar/complex.rs
@@ -5,7 +5,7 @@ use std::ops::Neg;
 use std::{f32, f64};
 
 use crate::scalar::{Field, RealField, SubsetOf, SupersetOf};
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), not(feature = "libm_force"), feature = "libm"))]
 use num::Float;
 //#[cfg(feature = "decimal")]
 //use decimal::d128;
@@ -468,7 +468,7 @@ macro_rules! impl_complex(
     )*)
 );
 
-#[cfg(all(not(feature = "std"), not(feature = "libm_force")))]
+#[cfg(all(not(feature = "std"), not(feature = "libm_force"), feature = "libm"))]
 impl_complex!(
     f32, f32, Float;
     f64, f64, Float
@@ -479,6 +479,7 @@ impl_complex!(
     f32,f32,f32;
     f64,f64,f64
 );
+
 #[cfg(feature = "libm_force")]
 impl ComplexField for f32 {
     type RealField = f32;

--- a/src/scalar/complex.rs
+++ b/src/scalar/complex.rs
@@ -182,6 +182,7 @@ pub trait ComplexField:
     fn try_sqrt(self) -> Option<Self>;
 }
 
+#[cfg(not(feature = "libm_force"))]
 macro_rules! impl_complex(
     ($($T:ty, $M:ident, $libm: ident);*) => ($(
         impl ComplexField for $T {
@@ -467,17 +468,564 @@ macro_rules! impl_complex(
     )*)
 );
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), not(feature = "libm_force")))]
 impl_complex!(
     f32, f32, Float;
     f64, f64, Float
 );
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "libm_force")))]
 impl_complex!(
     f32,f32,f32;
     f64,f64,f64
 );
+#[cfg(feature = "libm_force")]
+impl ComplexField for f32 {
+    type RealField = f32;
+
+    #[inline]
+    fn from_real(re: Self::RealField) -> Self {
+        re
+    }
+
+    #[inline]
+    fn real(self) -> Self::RealField {
+        self
+    }
+
+    #[inline]
+    fn imaginary(self) -> Self::RealField {
+        Self::zero()
+    }
+
+    #[inline]
+    fn norm1(self) -> Self::RealField {
+        libm_force::fabsf(self)
+    }
+
+    #[inline]
+    fn modulus(self) -> Self::RealField {
+        libm_force::fabsf(self)
+    }
+
+    #[inline]
+    fn modulus_squared(self) -> Self::RealField {
+        self * self
+    }
+
+    #[inline]
+    fn argument(self) -> Self::RealField {
+        if self >= Self::zero() {
+            Self::zero()
+        } else {
+            Self::pi()
+        }
+    }
+
+    #[inline]
+    fn to_exp(self) -> (Self, Self) {
+        if self >= Self::zero() {
+            (self, Self::one())
+        } else {
+            (-self, -Self::one())
+        }
+    }
+
+    #[inline]
+    fn recip(self) -> Self {
+        f32::recip(self)
+    }
+
+    #[inline]
+    fn conjugate(self) -> Self {
+        self
+    }
+
+    #[inline]
+    fn scale(self, factor: Self::RealField) -> Self {
+        self * factor
+    }
+
+    #[inline]
+    fn unscale(self, factor: Self::RealField) -> Self {
+        self / factor
+    }
+
+    #[inline]
+    fn floor(self) -> Self {
+        libm_force::floorf(self)
+    }
+
+    #[inline]
+    fn ceil(self) -> Self {
+        libm_force::ceilf(self)
+    }
+
+    #[inline]
+    fn round(self) -> Self {
+        libm_force::roundf(self)
+    }
+
+    #[inline]
+    fn trunc(self) -> Self {
+        libm_force::truncf(self)
+    }
+
+    #[inline]
+    fn fract(self) -> Self {
+        self - libm_force::truncf(self)
+    }
+
+    #[inline]
+    fn abs(self) -> Self {
+        libm_force::fabsf(self)
+    }
+
+    #[inline]
+    fn signum(self) -> Self {
+        Signed::signum(&self)
+    }
+
+    #[inline]
+    fn mul_add(self, a: Self, b: Self) -> Self {
+        libm_force::fmaf(self, a, b)
+    }
+
+    #[inline]
+    fn powi(self, n: i32) -> Self {
+        // TODO: implement a more accurate/efficient solution?
+        libm_force::powf(self, n as f32)
+    }
+
+    #[inline]
+    fn powf(self, n: Self) -> Self {
+        libm_force::powf(self, n)
+    }
+
+    #[inline]
+    fn powc(self, n: Self) -> Self {
+        // Same as powf.
+        libm_force::powf(self, n)
+    }
+
+    #[inline]
+    fn sqrt(self) -> Self {
+        libm_force::sqrtf(self)
+    }
+
+    #[inline]
+    fn try_sqrt(self) -> Option<Self> {
+        if self >= Self::zero() {
+            Some(libm_force::sqrtf(self))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn exp(self) -> Self {
+        libm_force::expf(self)
+    }
+
+    #[inline]
+    fn exp2(self) -> Self {
+        libm_force::exp2f(self)
+    }
+
+    #[inline]
+    fn exp_m1(self) -> Self {
+        libm_force::expm1f(self)
+    }
+
+    #[inline]
+    fn ln_1p(self) -> Self {
+        libm_force::log1pf(self)
+    }
+
+    #[inline]
+    fn ln(self) -> Self {
+        libm_force::logf(self)
+    }
+
+    #[inline]
+    fn log(self, base: Self) -> Self {
+        libm_force::logf(self) / libm_force::logf(base)
+    }
+
+    #[inline]
+    fn log2(self) -> Self {
+        libm_force::log2f(self)
+    }
+
+    #[inline]
+    fn log10(self) -> Self {
+        libm_force::log10f(self)
+    }
+
+    #[inline]
+    fn cbrt(self) -> Self {
+        libm_force::cbrtf(self)
+    }
+
+    #[inline]
+    fn hypot(self, other: Self) -> Self::RealField {
+        libm_force::hypotf(self, other)
+    }
+
+    #[inline]
+    fn sin(self) -> Self {
+        libm_force::sinf(self)
+    }
+
+    #[inline]
+    fn cos(self) -> Self {
+        libm_force::cosf(self)
+    }
+
+    #[inline]
+    fn tan(self) -> Self {
+        libm_force::tanf(self)
+    }
+
+    #[inline]
+    fn asin(self) -> Self {
+        libm_force::asinf(self)
+    }
+
+    #[inline]
+    fn acos(self) -> Self {
+        libm_force::acosf(self)
+    }
+
+    #[inline]
+    fn atan(self) -> Self {
+        libm_force::atanf(self)
+    }
+
+    #[inline]
+    fn sin_cos(self) -> (Self, Self) {
+        libm_force::sincosf(self)
+    }
+
+    //            #[inline]
+    //            fn exp_m1(self) -> Self {
+    //                libm_force::exp_m1(self)
+    //            }
+    //
+    //            #[inline]
+    //            fn ln_1p(self) -> Self {
+    //                libm_force::ln_1p(self)
+    //            }
+    //
+    #[inline]
+    fn sinh(self) -> Self {
+        libm_force::sinhf(self)
+    }
+
+    #[inline]
+    fn cosh(self) -> Self {
+        libm_force::coshf(self)
+    }
+
+    #[inline]
+    fn tanh(self) -> Self {
+        libm_force::tanhf(self)
+    }
+
+    #[inline]
+    fn asinh(self) -> Self {
+        libm_force::asinhf(self)
+    }
+
+    #[inline]
+    fn acosh(self) -> Self {
+        libm_force::acoshf(self)
+    }
+
+    #[inline]
+    fn atanh(self) -> Self {
+        libm_force::atanhf(self)
+    }
+
+    #[inline]
+    fn is_finite(&self) -> bool {
+        f32::is_finite(*self)
+    }
+}
+
+#[cfg(feature = "libm_force")]
+impl ComplexField for f64 {
+    type RealField = f64;
+
+    #[inline]
+    fn from_real(re: Self::RealField) -> Self {
+        re
+    }
+
+    #[inline]
+    fn real(self) -> Self::RealField {
+        self
+    }
+
+    #[inline]
+    fn imaginary(self) -> Self::RealField {
+        Self::zero()
+    }
+
+    #[inline]
+    fn norm1(self) -> Self::RealField {
+        libm_force::fabs(self)
+    }
+
+    #[inline]
+    fn modulus(self) -> Self::RealField {
+        libm_force::fabs(self)
+    }
+
+    #[inline]
+    fn modulus_squared(self) -> Self::RealField {
+        self * self
+    }
+
+    #[inline]
+    fn argument(self) -> Self::RealField {
+        if self >= Self::zero() {
+            Self::zero()
+        } else {
+            Self::pi()
+        }
+    }
+
+    #[inline]
+    fn to_exp(self) -> (Self, Self) {
+        if self >= Self::zero() {
+            (self, Self::one())
+        } else {
+            (-self, -Self::one())
+        }
+    }
+
+    #[inline]
+    fn recip(self) -> Self {
+        f64::recip(self)
+    }
+
+    #[inline]
+    fn conjugate(self) -> Self {
+        self
+    }
+
+    #[inline]
+    fn scale(self, factor: Self::RealField) -> Self {
+        self * factor
+    }
+
+    #[inline]
+    fn unscale(self, factor: Self::RealField) -> Self {
+        self / factor
+    }
+
+    #[inline]
+    fn floor(self) -> Self {
+        libm_force::floor(self)
+    }
+
+    #[inline]
+    fn ceil(self) -> Self {
+        libm_force::ceil(self)
+    }
+
+    #[inline]
+    fn round(self) -> Self {
+        libm_force::round(self)
+    }
+
+    #[inline]
+    fn trunc(self) -> Self {
+        libm_force::trunc(self)
+    }
+
+    #[inline]
+    fn fract(self) -> Self {
+        self - libm_force::trunc(self)
+    }
+
+    #[inline]
+    fn abs(self) -> Self {
+        libm_force::fabs(self)
+    }
+
+    #[inline]
+    fn signum(self) -> Self {
+        Signed::signum(&self)
+    }
+
+    #[inline]
+    fn mul_add(self, a: Self, b: Self) -> Self {
+        libm_force::fma(self, a, b)
+    }
+
+    #[inline]
+    fn powi(self, n: i32) -> Self {
+        // TODO: implement a more accurate solution?
+        libm_force::pow(self, n as f64)
+    }
+
+    #[inline]
+    fn powf(self, n: Self) -> Self {
+        libm_force::pow(self, n)
+    }
+
+    #[inline]
+    fn powc(self, n: Self) -> Self {
+        // Same as powf.
+        libm_force::pow(self, n)
+    }
+
+    #[inline]
+    fn sqrt(self) -> Self {
+        libm_force::sqrt(self)
+    }
+
+    #[inline]
+    fn try_sqrt(self) -> Option<Self> {
+        if self >= Self::zero() {
+            Some(libm_force::sqrt(self))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn exp(self) -> Self {
+        libm_force::exp(self)
+    }
+
+    #[inline]
+    fn exp2(self) -> Self {
+        libm_force::exp2(self)
+    }
+
+    #[inline]
+    fn exp_m1(self) -> Self {
+        libm_force::expm1(self)
+    }
+
+    #[inline]
+    fn ln_1p(self) -> Self {
+        libm_force::log1p(self)
+    }
+
+    #[inline]
+    fn ln(self) -> Self {
+        libm_force::log(self)
+    }
+
+    #[inline]
+    fn log(self, base: Self) -> Self {
+        libm_force::log(self) / libm_force::log(base)
+    }
+
+    #[inline]
+    fn log2(self) -> Self {
+        libm_force::log2(self)
+    }
+
+    #[inline]
+    fn log10(self) -> Self {
+        libm_force::log10(self)
+    }
+
+    #[inline]
+    fn cbrt(self) -> Self {
+        libm_force::cbrt(self)
+    }
+
+    #[inline]
+    fn hypot(self, other: Self) -> Self::RealField {
+        libm_force::hypot(self, other)
+    }
+
+    #[inline]
+    fn sin(self) -> Self {
+        libm_force::sin(self)
+    }
+
+    #[inline]
+    fn cos(self) -> Self {
+        libm_force::cos(self)
+    }
+
+    #[inline]
+    fn tan(self) -> Self {
+        libm_force::tan(self)
+    }
+
+    #[inline]
+    fn asin(self) -> Self {
+        libm_force::asin(self)
+    }
+
+    #[inline]
+    fn acos(self) -> Self {
+        libm_force::acos(self)
+    }
+
+    #[inline]
+    fn atan(self) -> Self {
+        libm_force::atan(self)
+    }
+
+    #[inline]
+    fn sin_cos(self) -> (Self, Self) {
+        libm_force::sincos(self)
+    }
+
+    //            #[inline]
+    //            fn exp_m1(self) -> Self {
+    //                libm_force::exp_m1(self)
+    //            }
+    //
+    //            #[inline]
+    //            fn ln_1p(self) -> Self {
+    //                libm_force::ln_1p(self)
+    //            }
+    //
+    #[inline]
+    fn sinh(self) -> Self {
+        libm_force::sinh(self)
+    }
+
+    #[inline]
+    fn cosh(self) -> Self {
+        libm_force::cosh(self)
+    }
+
+    #[inline]
+    fn tanh(self) -> Self {
+        libm_force::tanh(self)
+    }
+
+    #[inline]
+    fn asinh(self) -> Self {
+        libm_force::asinh(self)
+    }
+
+    #[inline]
+    fn acosh(self) -> Self {
+        libm_force::acosh(self)
+    }
+
+    #[inline]
+    fn atanh(self) -> Self {
+        libm_force::atanh(self)
+    }
+
+    #[inline]
+    fn is_finite(&self) -> bool {
+        f64::is_finite(*self)
+    }
+}
 
 //#[cfg(feature = "decimal")]
 //impl_real!(d128, d128, d128);

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -23,6 +23,12 @@ macro_rules! impl_fixed_type(
         /// Signed fixed-point number with a generic number of bits for the fractional part.
         pub struct $FixedI<Fract: $LeEqDim>(pub fixed::$FixedI<Fract>);
 
+        impl<Fract: $LeEqDim> $FixedI<Fract> {
+            pub fn from_num<N: fixed::traits::ToFixed>(val: N) -> Self {
+                $FixedI(fixed::$FixedI::from_num(val))
+            }
+        }
+
         impl<Fract: $LeEqDim> PartialEq for $FixedI<Fract> {
             #[inline(always)]
             fn eq(&self, other: &Self) -> bool {
@@ -714,6 +720,15 @@ macro_rules! impl_fixed_type(
             #[inline]
             fn is_sign_negative(self) -> bool {
                 self.0.is_negative()
+            }
+
+            #[inline]
+            fn copysign(self, rhs: Self) -> Self {
+                if self >= Self::zero() {
+                    rhs.abs()
+                } else {
+                    -rhs.abs()
+                }
             }
 
             #[inline]

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -192,9 +192,23 @@ macro_rules! impl_real(
     )*)
 );
 
-#[cfg(not(feature = "std"))]
-impl_real!(f32,f32,Float; f64,f64,Float);
-#[cfg(feature = "std")]
-impl_real!(f32,f32,f32; f64,f64,f64);
+#[cfg(all(not(feature = "std"), not(feature = "libm_force")))]
+impl_real!(f32, f32, Float; f64, f64, Float);
+#[cfg(all(feature = "std", not(feature = "libm_force")))]
+impl_real!(f32, f32, f32; f64, f64, f64);
+#[cfg(feature = "libm_force")]
+impl_real!(f32, f32, libm_force_f32; f64, f64, libm_force);
+
+// We use this dummy module to remove the 'f' suffix at the end of
+// each libm functions to make our generic Real/ComplexField impl
+// macros work.
+#[cfg(feature = "libm_force")]
+mod libm_force_f32 {
+    #[inline(always)]
+    pub fn atan2(y: f32, x: f32) -> f32 {
+        libm_force::atan2f(y, x)
+    }
+}
+
 //#[cfg(feature = "decimal")]
 //impl_real!(d128, d128, d128);

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -5,7 +5,7 @@ use approx::{RelativeEq, UlpsEq};
 
 use crate::scalar::ComplexField;
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), not(feature = "libm_force"), feature = "libm"))]
 use num::Float;
 //#[cfg(feature = "decimal")]
 //use decimal::d128;
@@ -192,7 +192,7 @@ macro_rules! impl_real(
     )*)
 );
 
-#[cfg(all(not(feature = "std"), not(feature = "libm_force")))]
+#[cfg(all(not(feature = "std"), not(feature = "libm_force"), feature = "libm"))]
 impl_real!(f32, f32, Float; f64, f64, Float);
 #[cfg(all(feature = "std", not(feature = "libm_force")))]
 impl_real!(f32, f32, f32; f64, f64, f64);

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -24,6 +24,11 @@ pub trait RealField:
     fn is_sign_positive(self) -> bool;
     /// Is the sign of this real number negative?
     fn is_sign_negative(self) -> bool;
+    /// Copies the sign of `self` to `to`.
+    ///
+    /// - Returns `to.simd_abs()` if `self` is positive or positive-zero.
+    /// - Returns `-to.simd_abs()` if `self` is negative or negative-zero.
+    fn copysign(self, to: Self) -> Self;
 
     fn max(self, other: Self) -> Self;
     fn min(self, other: Self) -> Self;
@@ -59,6 +64,12 @@ macro_rules! impl_real(
             #[inline]
             fn is_sign_negative(self) -> bool {
                 $M::is_sign_negative(self)
+            }
+
+            #[inline(always)]
+            fn copysign(self, to: Self) -> Self {
+                let signbit = (-0.0 as $T).to_bits();
+                Self::from_bits((signbit & self.to_bits()) | ((!signbit) & to.to_bits()))
             }
 
             #[inline]

--- a/src/simd/packed_simd_impl.rs
+++ b/src/simd/packed_simd_impl.rs
@@ -271,6 +271,15 @@ macro_rules! impl_uint_simd(
             }
         }
 
+        impl From<Simd<$t>> for [$elt; <$t>::lanes()] {
+            #[inline(always)]
+            fn from(val: Simd<$t>) -> [$elt; <$t>::lanes()] {
+                let mut res = [<$elt>::zero(); <$t>::lanes()];
+                val.0.write_to_slice_unaligned(&mut res[..]);
+                res
+            }
+        }
+
         impl SubsetOf<Simd<$t>> for Simd<$t> {
             #[inline(always)]
             fn to_superset(&self) -> Self {
@@ -507,6 +516,16 @@ macro_rules! impl_uint_simd(
             #[inline(always)]
             fn simd_clamp(self, min: Self, max: Self) -> Self {
                 self.simd_max(min).simd_min(max)
+            }
+
+            #[inline(always)]
+            fn simd_horizontal_min(self) -> Self::Element {
+                self.0.min_element()
+            }
+
+            #[inline(always)]
+            fn simd_horizontal_max(self) -> Self::Element {
+                self.0.max_element()
             }
         }
 

--- a/src/simd/packed_simd_impl.rs
+++ b/src/simd/packed_simd_impl.rs
@@ -78,6 +78,11 @@ macro_rules! impl_bool_simd(
 
         impl SimdBool for Simd<$t> {
             #[inline(always)]
+            fn bitmask(self) -> u64 {
+                self.0.bitmask() as u64
+            }
+
+            #[inline(always)]
             fn and(self) -> bool {
                 self.0.and()
             }

--- a/src/simd/packed_simd_impl.rs
+++ b/src/simd/packed_simd_impl.rs
@@ -14,107 +14,97 @@ use decimal::d128;
 use num::{FromPrimitive, Num, One, Zero};
 use std::{
     fmt,
-    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
+    ops::{
+        Add, AddAssign, BitAnd, BitOr, BitXor, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign,
+        Sub, SubAssign,
+    },
 };
+
+// This is a hack to allow use to reuse `_0` as integers or as identifier,
+// depending on whether or not `ident_to_value` has been called in scope.
+// This helps writing macros that define both `::new` and `From([T; lanes()])`.
+macro_rules! ident_to_value(
+    () => {
+        const _0: usize = 0; const _1: usize = 1; const _2: usize = 2; const _3: usize = 3; const _4: usize = 4; const _5: usize = 5; const _6: usize = 6; const _7: usize = 7;
+        const _8: usize = 8; const _9: usize = 9; const _10: usize = 10; const _11: usize = 11; const _12: usize = 12; const _13: usize = 13; const _14: usize = 14; const _15: usize = 15;
+        const _16: usize = 16; const _17: usize = 17; const _18: usize = 18; const _19: usize = 19; const _20: usize = 20; const _21: usize = 21; const _22: usize = 22; const _23: usize = 23;
+        const _24: usize = 24; const _25: usize = 25; const _26: usize = 26; const _27: usize = 27; const _28: usize = 28; const _29: usize = 29; const _30: usize = 30; const _31: usize = 31;
+        const _32: usize = 32; const _33: usize = 33; const _34: usize = 34; const _35: usize = 35; const _36: usize = 36; const _37: usize = 37; const _38: usize = 38; const _39: usize = 39;
+        const _40: usize = 40; const _41: usize = 41; const _42: usize = 42; const _43: usize = 43; const _44: usize = 44; const _45: usize = 45; const _46: usize = 46; const _47: usize = 47;
+        const _48: usize = 48; const _49: usize = 49; const _50: usize = 50; const _51: usize = 51; const _52: usize = 52; const _53: usize = 53; const _54: usize = 54; const _55: usize = 55;
+        const _56: usize = 56; const _57: usize = 57; const _58: usize = 58; const _59: usize = 59; const _60: usize = 60; const _61: usize = 61; const _62: usize = 62; const _63: usize = 63;
+    }
+);
 
 /// An Simd structure that implements all the relevant traits from `num` an `simba`.
 ///
 /// This is needed to overcome the orphan rules.
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Simd<N: SimdValue>(pub N);
+pub struct Simd<N>(pub N);
 
-impl<N: SimdValue + Copy> fmt::Display for Simd<N>
-where N::Element: fmt::Display
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if N::lanes() == 1 {
-            return self.extract(0).fmt(f);
+macro_rules! impl_bool_simd(
+    ($($t: ty, $($i: ident),*;)*) => {$(
+        impl_simd_value!($t, bool, Simd<$t> $(, $i)*;);
+
+        impl From<[bool; <$t>::lanes()]> for Simd<$t> {
+            #[inline(always)]
+            fn from(vals: [bool; <$t>::lanes()]) -> Self {
+                ident_to_value!();
+                Simd(<$t>::new($(vals[$i]),*))
+            }
         }
 
-        write!(f, "({}", self.extract(0))?;
-
-        for i in 1..N::lanes() {
-            write!(f, ", {}", self.extract(i))?;
+        impl BitAnd<Simd<$t>> for Simd<$t> {
+            type Output = Self;
+            fn bitand(self, rhs: Self) -> Self {
+                Simd(self.0.bitand(rhs.0))
+            }
         }
 
-        write!(f, ")")
-    }
-}
+        impl BitOr<Simd<$t>> for Simd<$t> {
+            type Output = Self;
+            fn bitor(self, rhs: Self) -> Self {
+                Simd(self.0.bitor(rhs.0))
+            }
+        }
 
-impl<N: PrimitiveSimdValue> PrimitiveSimdValue for Simd<N> {}
+        impl BitXor<Simd<$t>> for Simd<$t> {
+            type Output = Self;
+            fn bitxor(self, rhs: Self) -> Self {
+                Simd(self.0.bitxor(rhs.0))
+            }
+        }
 
-impl<N: SimdValue> SimdValue for Simd<N> {
-    type Element = N::Element;
-    type SimdBool = N::SimdBool;
-
-    #[inline(always)]
-    fn lanes() -> usize {
-        N::lanes()
-    }
-
-    #[inline(always)]
-    fn splat(val: Self::Element) -> Self {
-        Simd(N::splat(val))
-    }
-
-    #[inline(always)]
-    fn extract(&self, i: usize) -> Self::Element {
-        self.0.extract(i)
-    }
-
-    #[inline(always)]
-    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
-        self.0.extract_unchecked(i)
-    }
-
-    #[inline(always)]
-    fn replace(&mut self, i: usize, val: Self::Element) {
-        self.0.replace(i, val);
-    }
-
-    #[inline(always)]
-    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
-        self.0.replace_unchecked(i, val);
-    }
-
-    #[inline(always)]
-    fn select(self, cond: Self::SimdBool, other: Self) -> Self {
-        Simd(self.0.select(cond, other.0))
-    }
-}
-
-macro_rules! impl_simd_bool(
-    ($($t: ty;)*) => {$(
-        impl SimdBool for $t {
+        impl SimdBool for Simd<$t> {
             #[inline(always)]
             fn and(self) -> bool {
-                self.and()
+                self.0.and()
             }
 
             #[inline(always)]
             fn or(self) -> bool {
-                self.or()
+                self.0.or()
             }
 
             #[inline(always)]
             fn xor(self) -> bool {
-                self.xor()
+                self.0.xor()
             }
 
             #[inline(always)]
             fn all(self) -> bool {
-                self.all()
+                self.0.all()
             }
 
             #[inline(always)]
             fn any(self) -> bool {
-                self.any()
+                self.0.any()
             }
 
             #[inline(always)]
             fn none(self) -> bool {
-                self.none()
+                self.0.none()
             }
 
             #[inline(always)]
@@ -170,11 +160,12 @@ macro_rules! impl_simd_bool(
 
 macro_rules! impl_scalar_subset_of_simd(
     ($($t: ty),*) => {$(
-        impl<N2: SimdValue + Copy> SubsetOf<Simd<N2>> for $t
-            where N2::Element: SupersetOf<$t> + PartialEq {
+        impl<N2> SubsetOf<Simd<N2>> for $t
+            where Simd<N2>: SimdValue + Copy,
+                  <Simd<N2> as SimdValue>::Element: SupersetOf<$t> + PartialEq, {
             #[inline(always)]
             fn to_superset(&self) -> Simd<N2> {
-                Simd(N2::splat(N2::Element::from_subset(self)))
+                Simd::<N2>::splat(<Simd<N2> as SimdValue>::Element::from_subset(self))
             }
 
             #[inline(always)]
@@ -186,7 +177,7 @@ macro_rules! impl_scalar_subset_of_simd(
             fn is_in_subset(c: &Simd<N2>) -> bool {
                 let elt0 = c.extract(0);
                 elt0.is_in_subset() &&
-                (1..N2::lanes()).all(|i| c.extract(i) == elt0)
+                (1..Simd::<N2>::lanes()).all(|i| c.extract(i) == elt0)
             }
         }
     )*}
@@ -197,10 +188,32 @@ impl_scalar_subset_of_simd!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, 
 impl_scalar_subset_of_simd!(d128);
 
 macro_rules! impl_simd_value(
-    ($($t: ty, $elt: ty, $bool: ty;)*) => ($(
-        impl PrimitiveSimdValue for $t {}
+    ($($t: ty, $elt: ty, $bool: ty, $($i: ident),*;)*) => ($(
+        impl fmt::Display for Simd<$t> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                if Self::lanes() == 1 {
+                    return self.extract(0).fmt(f);
+                }
 
-        impl SimdValue for $t {
+                write!(f, "({}", self.extract(0))?;
+
+                for i in 1..Self::lanes() {
+                    write!(f, ", {}", self.extract(i))?;
+                }
+
+                write!(f, ")")
+            }
+        }
+
+        impl Simd<$t> {
+            pub fn new($($i: $elt),*) -> Self {
+                Simd(<$t>::new($($i),*))
+            }
+        }
+
+        impl PrimitiveSimdValue for Simd<$t> {}
+
+        impl SimdValue for Simd<$t> {
             type Element = $elt;
             type SimdBool = $bool;
 
@@ -211,40 +224,40 @@ macro_rules! impl_simd_value(
 
             #[inline(always)]
             fn splat(val: Self::Element) -> Self {
-                <$t>::splat(val)
+                Simd(<$t>::splat(val))
             }
 
             #[inline(always)]
             fn extract(&self, i: usize) -> Self::Element {
-                <$t>::extract(*self, i)
+                <$t>::extract(self.0, i)
             }
 
             #[inline(always)]
             unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
-                <$t>::extract_unchecked(*self, i)
+                <$t>::extract_unchecked(self.0, i)
             }
 
             #[inline(always)]
             fn replace(&mut self, i: usize, val: Self::Element) {
-                *self = <$t>::replace(*self, i, val)
+                *self = Simd(<$t>::replace(self.0, i, val))
             }
 
             #[inline(always)]
             unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
-                *self = <$t>::replace_unchecked(*self, i, val)
+                *self = Simd(<$t>::replace_unchecked(self.0, i, val))
             }
 
             #[inline(always)]
             fn select(self, cond: Self::SimdBool, other: Self) -> Self {
-                cond.select(self, other)
+                Self(cond.0.select(self.0, other.0))
             }
         }
     )*)
 );
 
 macro_rules! impl_uint_simd(
-    ($($t: ty, $elt: ty, $bool: ty;)*) => ($(
-        impl_simd_value!($t, $elt, $bool;);
+    ($($t: ty, $elt: ty, $bool: ty, $($i: ident),*;)*) => ($(
+        impl_simd_value!($t, $elt, $bool $(, $i)*;);
 
         impl From<[$elt; <$t>::lanes()]> for Simd<$t> {
             #[inline(always)]
@@ -449,32 +462,32 @@ macro_rules! impl_uint_simd(
         impl SimdPartialOrd for Simd<$t> {
             #[inline(always)]
             fn simd_gt(self, other: Self) -> Self::SimdBool {
-                self.0.gt(other.0)
+                Simd(self.0.gt(other.0))
             }
 
             #[inline(always)]
             fn simd_lt(self, other: Self) -> Self::SimdBool {
-                self.0.lt(other.0)
+                Simd(self.0.lt(other.0))
             }
 
             #[inline(always)]
             fn simd_ge(self, other: Self) -> Self::SimdBool {
-                self.0.ge(other.0)
+                Simd(self.0.ge(other.0))
             }
 
             #[inline(always)]
             fn simd_le(self, other: Self) -> Self::SimdBool {
-                self.0.le(other.0)
+                Simd(self.0.le(other.0))
             }
 
             #[inline(always)]
             fn simd_eq(self, other: Self) -> Self::SimdBool {
-                self.0.eq(other.0)
+                Simd(self.0.eq(other.0))
             }
 
             #[inline(always)]
             fn simd_ne(self, other: Self) -> Self::SimdBool {
-                self.0.ne(other.0)
+                Simd(self.0.ne(other.0))
             }
 
             #[inline(always)]
@@ -509,8 +522,8 @@ macro_rules! impl_uint_simd(
 );
 
 macro_rules! impl_int_simd(
-    ($($t: ty, $elt: ty, $bool: ty;)*) => ($(
-        impl_uint_simd!($t, $elt, $bool;);
+    ($($t: ty, $elt: ty, $bool: ty, $($i: ident),*;)*) => ($(
+        impl_uint_simd!($t, $elt, $bool $(, $i)*;);
 
         impl Neg for Simd<$t> {
             type Output = Self;
@@ -524,8 +537,8 @@ macro_rules! impl_int_simd(
 );
 
 macro_rules! impl_float_simd(
-    ($($t: ty, $elt: ty, $int: ty, $bool: ty;)*) => ($(
-        impl_int_simd!($t, $elt, $bool;);
+    ($($t: ty, $elt: ty, $int: ty, $bool: ty, $($i: ident),*;)*) => ($(
+        impl_int_simd!($t, $elt, $bool $(, $i)*;);
 
         // FIXME: this should be part of impl_int_simd
         // but those methods do not seem to be implemented
@@ -730,27 +743,27 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_floor(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.floor()))
+                self.map_lanes(|e| e.floor())
             }
 
             #[inline(always)]
             fn simd_ceil(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.ceil()))
+                self.map_lanes(|e| e.ceil())
             }
 
             #[inline(always)]
             fn simd_round(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.round()))
+                self.map_lanes(|e| e.round())
             }
 
             #[inline(always)]
             fn simd_trunc(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.trunc()))
+                self.map_lanes(|e| e.trunc())
             }
 
             #[inline(always)]
             fn simd_fract(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.fract()))
+                self.map_lanes(|e| e.fract())
             }
 
             #[inline(always)]
@@ -760,7 +773,7 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_signum(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.signum()))
+                self.map_lanes(|e| e.signum())
             }
 
             #[inline(always)]
@@ -795,18 +808,18 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_exp2(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.exp2()))
+                self.map_lanes(|e| e.exp2())
             }
 
 
             #[inline(always)]
             fn simd_exp_m1(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.exp_m1()))
+                self.map_lanes(|e| e.exp_m1())
             }
 
             #[inline(always)]
             fn simd_ln_1p(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.ln_1p()))
+                self.map_lanes(|e| e.ln_1p())
             }
 
             #[inline(always)]
@@ -816,27 +829,27 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_log(self, base: Self) -> Self {
-                Simd(self.0.zip_map_lanes(base.0, |e, b| e.log(b)))
+                self.zip_map_lanes(base, |e, b| e.log(b))
             }
 
             #[inline(always)]
             fn simd_log2(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.log2()))
+                self.map_lanes(|e| e.log2())
             }
 
             #[inline(always)]
             fn simd_log10(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.log10()))
+                self.map_lanes(|e| e.log10())
             }
 
             #[inline(always)]
             fn simd_cbrt(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.cbrt()))
+                self.map_lanes(|e| e.cbrt())
             }
 
             #[inline(always)]
             fn simd_hypot(self, other: Self) -> Self::SimdRealField {
-                Simd(self.0.zip_map_lanes(other.0, |e, o| e.hypot(o)))
+                self.zip_map_lanes(other, |e, o| e.hypot(o))
             }
 
             #[inline(always)]
@@ -851,22 +864,22 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_tan(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.tan()))
+                self.map_lanes(|e| e.tan())
             }
 
             #[inline(always)]
             fn simd_asin(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.asin()))
+                self.map_lanes(|e| e.asin())
             }
 
             #[inline(always)]
             fn simd_acos(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.acos()))
+                self.map_lanes(|e| e.acos())
             }
 
             #[inline(always)]
             fn simd_atan(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.atan()))
+                self.map_lanes(|e| e.atan())
             }
 
             #[inline(always)]
@@ -886,32 +899,32 @@ macro_rules! impl_float_simd(
 //
             #[inline(always)]
             fn simd_sinh(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.sinh()))
+                self.map_lanes(|e| e.sinh())
             }
 
             #[inline(always)]
             fn simd_cosh(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.cosh()))
+                self.map_lanes(|e| e.cosh())
             }
 
             #[inline(always)]
             fn simd_tanh(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.tanh()))
+                self.map_lanes(|e| e.tanh())
             }
 
             #[inline(always)]
             fn simd_asinh(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.asinh()))
+                self.map_lanes(|e| e.asinh())
             }
 
             #[inline(always)]
             fn simd_acosh(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.acosh()))
+                self.map_lanes(|e| e.acosh())
             }
 
             #[inline(always)]
             fn simd_atanh(self) -> Self {
-                Simd(self.0.map_lanes(|e| e.atanh()))
+                self.map_lanes(|e| e.atanh())
             }
         }
 
@@ -1343,121 +1356,94 @@ fn simd_complex_from_polar<N: SimdRealField>(r: N, theta: N) -> num_complex::Com
 }
 
 impl_float_simd!(
-    packed_simd::f32x2, f32, packed_simd::i32x2, m32x2;
-    packed_simd::f32x4, f32, packed_simd::i32x4, m32x4;
-    packed_simd::f32x8, f32, packed_simd::i32x8, m32x8;
-    packed_simd::f32x16, f32, packed_simd::i32x16, m32x16;
-    packed_simd::f64x2, f64, packed_simd::i64x2, m64x2;
-    packed_simd::f64x4, f64, packed_simd::i64x4, m64x4;
-    packed_simd::f64x8, f64, packed_simd::i64x8, m64x8;
+    packed_simd::f32x2, f32, packed_simd::i32x2, m32x2, _0, _1;
+    packed_simd::f32x4, f32, packed_simd::i32x4, m32x4, _0, _1, _2, _3;
+    packed_simd::f32x8, f32, packed_simd::i32x8, m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::f32x16, f32, packed_simd::i32x16, m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::f64x2, f64, packed_simd::i64x2, m64x2, _0, _1;
+    packed_simd::f64x4, f64, packed_simd::i64x4, m64x4, _0, _1, _2, _3;
+    packed_simd::f64x8, f64, packed_simd::i64x8, m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
 impl_int_simd!(
-    packed_simd::i128x1, i128, m128x1;
-    packed_simd::i128x2, i128, m128x2;
-    packed_simd::i128x4, i128, m128x4;
-    packed_simd::i16x2, i16, m16x2;
-    packed_simd::i16x4, i16, m16x4;
-    packed_simd::i16x8, i16, m16x8;
-    packed_simd::i16x16, i16, m16x16;
-    packed_simd::i16x32, i16, m16x32;
-    packed_simd::i32x2, i32, m32x2;
-    packed_simd::i32x4, i32, m32x4;
-    packed_simd::i32x8, i32, m32x8;
-    packed_simd::i32x16, i32, m32x16;
-    packed_simd::i64x2, i64, m64x2;
-    packed_simd::i64x4, i64, m64x4;
-    packed_simd::i64x8, i64, m64x8;
-    packed_simd::i8x2, i8, m8x2;
-    packed_simd::i8x4, i8, m8x4;
-    packed_simd::i8x8, i8, m8x8;
-    packed_simd::i8x16, i8, m8x16;
-    packed_simd::i8x32, i8, m8x32;
-    packed_simd::i8x64, i8, m8x64;
-    packed_simd::isizex2, isize, msizex2;
-    packed_simd::isizex4, isize, msizex4;
-    packed_simd::isizex8, isize, msizex8;
+    packed_simd::i128x1, i128, m128x1, _0;
+    packed_simd::i128x2, i128, m128x2, _0, _1;
+    packed_simd::i128x4, i128, m128x4, _0, _1, _2, _3;
+    packed_simd::i16x2, i16, m16x2, _0, _1;
+    packed_simd::i16x4, i16, m16x4, _0, _1, _2, _3;
+    packed_simd::i16x8, i16, m16x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::i16x16, i16, m16x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::i16x32, i16, m16x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    packed_simd::i32x2, i32, m32x2, _0, _1;
+    packed_simd::i32x4, i32, m32x4, _0, _1, _2, _3;
+    packed_simd::i32x8, i32, m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::i32x16, i32, m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::i64x2, i64, m64x2, _0, _1;
+    packed_simd::i64x4, i64, m64x4, _0, _1, _2, _3;
+    packed_simd::i64x8, i64, m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::i8x2, i8, m8x2, _0, _1;
+    packed_simd::i8x4, i8, m8x4, _0, _1, _2, _3;
+    packed_simd::i8x8, i8, m8x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::i8x16, i8, m8x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::i8x32, i8, m8x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    packed_simd::i8x64, i8, m8x64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
+    packed_simd::isizex2, isize, msizex2, _0, _1;
+    packed_simd::isizex4, isize, msizex4, _0, _1, _2, _3;
+    packed_simd::isizex8, isize, msizex8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
 impl_uint_simd!(
-    packed_simd::u128x1, u128, m128x1;
-    packed_simd::u128x2, u128, m128x2;
-    packed_simd::u128x4, u128, m128x4;
-    packed_simd::u16x2, u16, m16x2;
-    packed_simd::u16x4, u16, m16x4;
-    packed_simd::u16x8, u16, m16x8;
-    packed_simd::u16x16, u16, m16x16;
-    packed_simd::u16x32, u16, m16x32;
-    packed_simd::u32x2, u32, m32x2;
-    packed_simd::u32x4, u32, m32x4;
-    packed_simd::u32x8, u32, m32x8;
-    packed_simd::u32x16, u32, m32x16;
-    packed_simd::u64x2, u64, m64x2;
-    packed_simd::u64x4, u64, m64x4;
-    packed_simd::u64x8, u64, m64x8;
-    packed_simd::u8x2, u8, m8x2;
-    packed_simd::u8x4, u8, m8x4;
-    packed_simd::u8x8, u8, m8x8;
-    packed_simd::u8x16, u8, m8x16;
-    packed_simd::u8x32, u8, m8x32;
-    packed_simd::u8x64, u8, m8x64;
-    packed_simd::usizex2, usize, msizex2;
-    packed_simd::usizex4, usize, msizex4;
-    packed_simd::usizex8, usize, msizex8;
+    packed_simd::u128x1, u128, m128x1, _0;
+    packed_simd::u128x2, u128, m128x2, _0, _1;
+    packed_simd::u128x4, u128, m128x4, _0, _1, _2, _3;
+    packed_simd::u16x2, u16, m16x2, _0, _1;
+    packed_simd::u16x4, u16, m16x4, _0, _1, _2, _3;
+    packed_simd::u16x8, u16, m16x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::u16x16, u16, m16x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::u16x32, u16, m16x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    packed_simd::u32x2, u32, m32x2, _0, _1;
+    packed_simd::u32x4, u32, m32x4, _0, _1, _2, _3;
+    packed_simd::u32x8, u32, m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::u32x16, u32, m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::u64x2, u64, m64x2, _0, _1;
+    packed_simd::u64x4, u64, m64x4, _0, _1, _2, _3;
+    packed_simd::u64x8, u64, m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::u8x2, u8, m8x2, _0, _1;
+    packed_simd::u8x4, u8, m8x4, _0, _1, _2, _3;
+    packed_simd::u8x8, u8, m8x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::u8x16, u8, m8x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::u8x32, u8, m8x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    packed_simd::u8x64, u8, m8x64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
+    packed_simd::usizex2, usize, msizex2, _0, _1;
+    packed_simd::usizex4, usize, msizex4, _0, _1, _2, _3;
+    packed_simd::usizex8, usize, msizex8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
-impl_simd_value!(
-    m128x1, bool, m128x1;
-    m128x2, bool, m128x2;
-    m128x4, bool, m128x4;
-    m16x2, bool, m16x2;
-    m16x4, bool, m16x4;
-    m16x8, bool, m16x8;
-    m16x16, bool, m16x16;
-    m16x32, bool, m16x32;
-    m32x2, bool, m32x2;
-    m32x4, bool, m32x4;
-    m32x8, bool, m32x8;
-    m32x16, bool, m32x16;
-    m64x2, bool, m64x2;
-    m64x4, bool, m64x4;
-    m64x8, bool, m64x8;
-    m8x2, bool, m8x2;
-    m8x4, bool, m8x4;
-    m8x8, bool, m8x8;
-    m8x16, bool, m8x16;
-    m8x32, bool, m8x32;
-    m8x64, bool, m8x64;
-    msizex2, bool, msizex2;
-    msizex4, bool, msizex4;
-    msizex8, bool, msizex8;
-);
-
-impl_simd_bool!(
-    packed_simd::m128x1;
-    packed_simd::m128x2;
-    packed_simd::m128x4;
-    packed_simd::m16x2;
-    packed_simd::m16x4;
-    packed_simd::m16x8;
-    packed_simd::m16x16;
-    packed_simd::m16x32;
-    packed_simd::m32x2;
-    packed_simd::m32x4;
-    packed_simd::m32x8;
-    packed_simd::m32x16;
-    packed_simd::m64x2;
-    packed_simd::m64x4;
-    packed_simd::m64x8;
-    packed_simd::m8x2;
-    packed_simd::m8x4;
-    packed_simd::m8x8;
-    packed_simd::m8x16;
-    packed_simd::m8x32;
-    packed_simd::m8x64;
-    packed_simd::msizex2;
-    packed_simd::msizex4;
-    packed_simd::msizex8;
+impl_bool_simd!(
+    packed_simd::m128x1, _0;
+    packed_simd::m128x2, _0, _1;
+    packed_simd::m128x4, _0, _1, _2, _3;
+    packed_simd::m16x2, _0, _1;
+    packed_simd::m16x4, _0, _1, _2, _3;
+    packed_simd::m16x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::m16x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::m16x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    packed_simd::m32x2, _0, _1;
+    packed_simd::m32x4, _0, _1, _2, _3;
+    packed_simd::m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::m64x2, _0, _1;
+    packed_simd::m64x4, _0, _1, _2, _3;
+    packed_simd::m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::m8x2, _0, _1;
+    packed_simd::m8x4, _0, _1, _2, _3;
+    packed_simd::m8x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    packed_simd::m8x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    packed_simd::m8x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    packed_simd::m8x64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
+    packed_simd::msizex2, _0, _1;
+    packed_simd::msizex4, _0, _1, _2, _3;
+    packed_simd::msizex8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
 //
@@ -1544,27 +1530,27 @@ pub type usizex2 = Simd<packed_simd::usizex2>;
 pub type usizex4 = Simd<packed_simd::usizex4>;
 pub type usizex8 = Simd<packed_simd::usizex8>;
 
-pub use packed_simd::m128x1;
-pub use packed_simd::m128x2;
-pub use packed_simd::m128x4;
-pub use packed_simd::m16x16;
-pub use packed_simd::m16x2;
-pub use packed_simd::m16x32;
-pub use packed_simd::m16x4;
-pub use packed_simd::m16x8;
-pub use packed_simd::m32x16;
-pub use packed_simd::m32x2;
-pub use packed_simd::m32x4;
-pub use packed_simd::m32x8;
-pub use packed_simd::m64x2;
-pub use packed_simd::m64x4;
-pub use packed_simd::m64x8;
-pub use packed_simd::m8x16;
-pub use packed_simd::m8x2;
-pub use packed_simd::m8x32;
-pub use packed_simd::m8x4;
-pub use packed_simd::m8x64;
-pub use packed_simd::m8x8;
-pub use packed_simd::msizex2;
-pub use packed_simd::msizex4;
-pub use packed_simd::msizex8;
+pub type m128x1 = Simd<packed_simd::m128x1>;
+pub type m128x2 = Simd<packed_simd::m128x2>;
+pub type m128x4 = Simd<packed_simd::m128x4>;
+pub type m16x16 = Simd<packed_simd::m16x16>;
+pub type m16x2 = Simd<packed_simd::m16x2>;
+pub type m16x32 = Simd<packed_simd::m16x32>;
+pub type m16x4 = Simd<packed_simd::m16x4>;
+pub type m16x8 = Simd<packed_simd::m16x8>;
+pub type m32x16 = Simd<packed_simd::m32x16>;
+pub type m32x2 = Simd<packed_simd::m32x2>;
+pub type m32x4 = Simd<packed_simd::m32x4>;
+pub type m32x8 = Simd<packed_simd::m32x8>;
+pub type m64x2 = Simd<packed_simd::m64x2>;
+pub type m64x4 = Simd<packed_simd::m64x4>;
+pub type m64x8 = Simd<packed_simd::m64x8>;
+pub type m8x16 = Simd<packed_simd::m8x16>;
+pub type m8x2 = Simd<packed_simd::m8x2>;
+pub type m8x32 = Simd<packed_simd::m8x32>;
+pub type m8x4 = Simd<packed_simd::m8x4>;
+pub type m8x64 = Simd<packed_simd::m8x64>;
+pub type m8x8 = Simd<packed_simd::m8x8>;
+pub type msizex2 = Simd<packed_simd::msizex2>;
+pub type msizex4 = Simd<packed_simd::msizex4>;
+pub type msizex8 = Simd<packed_simd::msizex8>;

--- a/src/simd/simd_bool.rs
+++ b/src/simd/simd_bool.rs
@@ -9,6 +9,10 @@ use std::ops::{BitAnd, BitOr, BitXor};
 pub trait SimdBool:
     Copy + BitAnd<Self, Output = Self> + BitOr<Self, Output = Self> + BitXor<Self, Output = Self>
 {
+    /// A bit mask representing the boolean state of each lanes of `self`.
+    ///
+    /// The `i-th` bit of the result is `1` iff. the `i-th` lane of `self` is `true`.
+    fn bitmask(self) -> u64;
     /// Lane-wise bitwise and of the vector elements.
     fn and(self) -> bool;
     /// Lane-wise bitwise or of the vector elements.
@@ -67,6 +71,11 @@ pub trait SimdBool:
 
 impl SimdBool for bool {
     #[inline(always)]
+    fn bitmask(self) -> u64 {
+        self as u64
+    }
+
+    #[inline(always)]
     fn and(self) -> bool {
         self
     }
@@ -101,7 +110,8 @@ impl SimdBool for bool {
         self,
         if_value: impl FnOnce() -> Res,
         else_value: impl FnOnce() -> Res,
-    ) -> Res {
+    ) -> Res
+    {
         if self {
             if_value()
         } else {
@@ -115,7 +125,8 @@ impl SimdBool for bool {
         if_value: impl FnOnce() -> Res,
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res {
+    ) -> Res
+    {
         if self {
             if_value()
         } else if else_if.0() {
@@ -132,7 +143,8 @@ impl SimdBool for bool {
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res {
+    ) -> Res
+    {
         if self {
             if_value()
         } else if else_if.0() {

--- a/src/simd/simd_bool.rs
+++ b/src/simd/simd_bool.rs
@@ -110,8 +110,7 @@ impl SimdBool for bool {
         self,
         if_value: impl FnOnce() -> Res,
         else_value: impl FnOnce() -> Res,
-    ) -> Res
-    {
+    ) -> Res {
         if self {
             if_value()
         } else {
@@ -125,8 +124,7 @@ impl SimdBool for bool {
         if_value: impl FnOnce() -> Res,
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res
-    {
+    ) -> Res {
         if self {
             if_value()
         } else if else_if.0() {
@@ -143,8 +141,7 @@ impl SimdBool for bool {
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res
-    {
+    ) -> Res {
         if self {
             if_value()
         } else if else_if.0() {

--- a/src/simd/simd_partial_ord.rs
+++ b/src/simd/simd_partial_ord.rs
@@ -19,11 +19,16 @@ pub trait SimdPartialOrd: SimdValue {
     fn simd_max(self, other: Self) -> Self;
     /// Lanewise min value.
     fn simd_min(self, other: Self) -> Self;
-    /// Clamps each lane of `self` between the correspondin lane of `min` and `max`.
+    /// Clamps each lane of `self` between the corresponding lane of `min` and `max`.
     fn simd_clamp(self, min: Self, max: Self) -> Self;
+
+    /// The min value among all lanes of `self`.
+    fn simd_horizontal_min(self) -> Self::Element;
+    /// The max value among all lanes of `self`.
+    fn simd_horizontal_max(self) -> Self::Element;
 }
 
-impl<T: PartialOrd + SimdValue<SimdBool = bool>> SimdPartialOrd for T {
+impl<T: PartialOrd + SimdValue<Element = T, SimdBool = bool>> SimdPartialOrd for T {
     #[inline(always)]
     fn simd_gt(self, other: Self) -> Self::SimdBool {
         self > other
@@ -81,5 +86,15 @@ impl<T: PartialOrd + SimdValue<SimdBool = bool>> SimdPartialOrd for T {
         } else {
             self
         }
+    }
+
+    #[inline(always)]
+    fn simd_horizontal_min(self) -> Self::Element {
+        self
+    }
+
+    #[inline(always)]
+    fn simd_horizontal_max(self) -> Self::Element {
+        self
     }
 }

--- a/src/simd/simd_real.rs
+++ b/src/simd/simd_real.rs
@@ -9,6 +9,11 @@ use crate::simd::{SimdComplexField, SimdPartialOrd, SimdSigned};
 pub trait SimdRealField:
     SimdPartialOrd + SimdSigned + SimdComplexField<SimdRealField = Self>
 {
+    /// Copies the sign of `self` to `to`.
+    ///
+    /// - Returns `to.simd_abs()` if `self` is positive or positive-zero.
+    /// - Returns `-to.simd_abs()` if `self` is negative or negative-zero.
+    fn simd_copysign(self, to: Self) -> Self;
     fn simd_atan2(self, other: Self) -> Self;
 
     fn simd_default_epsilon() -> Self;
@@ -40,6 +45,10 @@ impl<T: RealField> SimdRealField for T {
     #[inline(always)]
     fn simd_default_epsilon() -> Self {
         Self::default_epsilon()
+    }
+    #[inline(always)]
+    fn simd_copysign(self, to: Self) -> Self {
+        self.copysign(to)
     }
     #[inline(always)]
     fn simd_pi() -> Self {

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -205,7 +205,8 @@ impl SimdBool for WideBoolF32x4 {
         self,
         if_value: impl FnOnce() -> Res,
         else_value: impl FnOnce() -> Res,
-    ) -> Res {
+    ) -> Res
+    {
         let a = if_value();
         let b = else_value();
         a.select(self, b)
@@ -217,7 +218,8 @@ impl SimdBool for WideBoolF32x4 {
         if_value: impl FnOnce() -> Res,
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res {
+    ) -> Res
+    {
         let a = if_value();
         let b = else_if.1();
         let c = else_value();
@@ -235,7 +237,8 @@ impl SimdBool for WideBoolF32x4 {
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res {
+    ) -> Res
+    {
         let a = if_value();
         let b = else_if.1();
         let c = else_else_if.1();
@@ -598,6 +601,11 @@ impl SimdRealField for WideF32x4 {
     #[inline(always)]
     fn simd_atan2(self, other: Self) -> Self {
         self.zip_map_lanes(other, |a, b| a.atan2(b))
+    }
+
+    #[inline(always)]
+    fn simd_copysign(self, to: Self) -> Self {
+        WideF32x4(self.0.copysign(to.0))
     }
 
     #[inline(always)]

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -168,6 +168,15 @@ impl BitAnd for WideBoolF32x4 {
 
 impl SimdBool for WideBoolF32x4 {
     #[inline(always)]
+    fn bitmask(self) -> u64 {
+        let arr = self.0.as_ref();
+        (((arr[0] != 0.0) as u64) << 0)
+            | (((arr[1] != 0.0) as u64) << 1)
+            | (((arr[2] != 0.0) as u64) << 2)
+            | (((arr[3] != 0.0) as u64) << 3)
+    }
+
+    #[inline(always)]
     fn and(self) -> bool {
         let arr = self.0.as_ref();
         (arr[0].to_bits() & arr[1].to_bits() & arr[2].to_bits() & arr[3].to_bits()) != 0

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -295,6 +295,13 @@ impl From<[f32; 4]> for WideF32x4 {
     }
 }
 
+impl From<WideF32x4> for [f32; 4] {
+    #[inline(always)]
+    fn from(val: WideF32x4) -> [f32; 4] {
+        *val.0.as_ref()
+    }
+}
+
 impl SubsetOf<WideF32x4> for WideF32x4 {
     #[inline(always)]
     fn to_superset(&self) -> Self {
@@ -566,6 +573,18 @@ impl SimdPartialOrd for WideF32x4 {
     fn simd_clamp(self, min: Self, max: Self) -> Self {
         WideF32x4(self.0.clamp(min.0, max.0))
     }
+
+    #[inline(always)]
+    fn simd_horizontal_min(self) -> Self::Element {
+        let arr = self.0.as_ref();
+        arr[0].min(arr[1]).min(arr[2]).min(arr[3])
+    }
+
+    #[inline(always)]
+    fn simd_horizontal_max(self) -> Self::Element {
+        let arr = self.0.as_ref();
+        arr[0].max(arr[1]).max(arr[2]).max(arr[3])
+    }
 }
 
 impl Neg for WideF32x4 {
@@ -614,7 +633,8 @@ impl SimdRealField for WideF32x4 {
 
     #[inline(always)]
     fn simd_copysign(self, to: Self) -> Self {
-        WideF32x4(self.0.copysign(to.0))
+        // WideF32x4(self.0.copysign(to.0))
+        WideF32x4((wide::f32x4::NEGATIVE_ZERO & self.0) | ((!wide::f32x4::NEGATIVE_ZERO) & to.0))
     }
 
     #[inline(always)]

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -214,8 +214,7 @@ impl SimdBool for WideBoolF32x4 {
         self,
         if_value: impl FnOnce() -> Res,
         else_value: impl FnOnce() -> Res,
-    ) -> Res
-    {
+    ) -> Res {
         let a = if_value();
         let b = else_value();
         a.select(self, b)
@@ -227,8 +226,7 @@ impl SimdBool for WideBoolF32x4 {
         if_value: impl FnOnce() -> Res,
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res
-    {
+    ) -> Res {
         let a = if_value();
         let b = else_if.1();
         let c = else_value();
@@ -246,8 +244,7 @@ impl SimdBool for WideBoolF32x4 {
         else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_else_if: (impl FnOnce() -> Self, impl FnOnce() -> Res),
         else_value: impl FnOnce() -> Res,
-    ) -> Res
-    {
+    ) -> Res {
         let a = if_value();
         let b = else_if.1();
         let c = else_else_if.1();


### PR DESCRIPTION
So far the SIMD booleans were the only SIMD types not wrapped in our own `Simd<_>`. In order to implement some conversion from/to arrays, it is necessary to wrap this in our own `Simd<_>` just like float SIMD types.

This PR also:
- adds `simd_horizontal_min` and `simd_horizontal_max`.
- adds a simd `copysign`.
- adds a `libm_force` feature that force the use of `libm` even when we don't target `no-std`.
- the use of `libm` is now opt-in when targetting `no-std`. This will prevent hidden performance regression when `default-features = false` is activated without being aware this will automatically switch all operation to libm.
