### PR TITLE
Add SIMD floats based on auto-vectorization.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-traits  = { version = "0.2.11", default-features = false }
 approx      = { version = "0.3", default-features = false }
 decimal     = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.2", default-features = false }
-packed_simd = { version = "0.3", features = [ "into_bits" ], optional = true }
+packed_simd = { package = "packed_simd_2", version = "0.3", features = [ "into_bits" ], optional = true }
 wide        = { version = "0.4", optional = true }
 fixed       = { version = "1", optional = true }
 cordic      = { version = "0.1", optional = true }

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -1,9 +1,9 @@
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)] // For the simd type aliases.
 
-//! Traits for SIMD values.
+//! SIMD values based on auto-vectorization.
 
-use crate::scalar::{ComplexField, Field, SubsetOf, SupersetOf};
+use crate::scalar::{Field, SubsetOf, SupersetOf};
 use crate::simd::{
     PrimitiveSimdValue, SimdBool, SimdComplexField, SimdPartialOrd, SimdRealField, SimdSigned,
     SimdValue,
@@ -39,86 +39,103 @@ macro_rules! ident_to_value(
 /// An Simd structure that implements all the relevant traits from `num` an `simba`.
 ///
 /// This is needed to overcome the orphan rules.
-#[repr(transparent)]
+#[repr(align(16))]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Simd<N>(pub N);
+pub struct AutoSimd<N>(pub N);
+/// An Simd boolean structure that implements all the relevant traits from `num` an `simba`.
+///
+/// This is needed to overcome the orphan rules.
+#[repr(align(16))]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct AutoBoolSimd<N>(pub N);
 
 macro_rules! impl_bool_simd(
-    ($($t: ty, $($i: ident),*;)*) => {$(
-        impl_simd_value!($t, bool, Simd<$t> $(, $i)*;);
+    ($($t: ty, $lanes: expr, $($i: ident),*;)*) => {$(
+        impl_simd_value!($t, bool, $lanes, AutoSimd<$t> $(, $i)*;);
 
-        impl From<[bool; <$t>::lanes()]> for Simd<$t> {
+        impl From<[bool; $lanes]> for AutoSimd<$t> {
             #[inline(always)]
-            fn from(vals: [bool; <$t>::lanes()]) -> Self {
-                ident_to_value!();
-                Simd(<$t>::new($(vals[$i]),*))
+            fn from(vals: [bool; $lanes]) -> Self {
+                Self(vals)
             }
         }
 
-        impl Not for Simd<$t> {
+        impl Not for AutoSimd<$t> {
             type Output = Self;
 
             #[inline]
             fn not(self) -> Self {
-                Self(!self.0)
+                self.map(|x| !x)
             }
         }
 
-        impl BitAnd<Simd<$t>> for Simd<$t> {
+        impl BitAnd<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
             fn bitand(self, rhs: Self) -> Self {
-                Simd(self.0.bitand(rhs.0))
+                self.zip_map(rhs, |x, y| x & y)
             }
         }
 
-        impl BitOr<Simd<$t>> for Simd<$t> {
+        impl BitOr<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
             fn bitor(self, rhs: Self) -> Self {
-                Simd(self.0.bitor(rhs.0))
+                self.zip_map(rhs, |x, y| x | y)
             }
         }
 
-        impl BitXor<Simd<$t>> for Simd<$t> {
+        impl BitXor<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
             fn bitxor(self, rhs: Self) -> Self {
-                Simd(self.0.bitxor(rhs.0))
+                self.zip_map(rhs, |x, y| x ^ y)
             }
         }
 
-        impl SimdBool for Simd<$t> {
+        impl SimdBool for AutoSimd<$t> {
             #[inline(always)]
             fn bitmask(self) -> u64 {
-                self.0.bitmask() as u64
+                ident_to_value!();
+                0u64 $(
+                    | ((self.0[$i] as u64) << $i)
+                 )*
             }
 
             #[inline(always)]
             fn and(self) -> bool {
-                self.0.and()
+                ident_to_value!();
+                true $(
+                    && self.0[$i]
+                 )*
             }
 
             #[inline(always)]
             fn or(self) -> bool {
-                self.0.or()
+                ident_to_value!();
+                false $(
+                    || self.0[$i]
+                 )*
             }
 
             #[inline(always)]
             fn xor(self) -> bool {
-                self.0.xor()
+                ident_to_value!();
+                false $(
+                    ^ self.0[$i]
+                 )*
             }
 
             #[inline(always)]
             fn all(self) -> bool {
-                self.0.all()
+                self.and()
             }
 
             #[inline(always)]
             fn any(self) -> bool {
-                self.0.any()
+                self.or()
             }
 
             #[inline(always)]
             fn none(self) -> bool {
-                self.0.none()
+                !self.any()
             }
 
             #[inline(always)]
@@ -174,24 +191,24 @@ macro_rules! impl_bool_simd(
 
 macro_rules! impl_scalar_subset_of_simd(
     ($($t: ty),*) => {$(
-        impl<N2> SubsetOf<Simd<N2>> for $t
-            where Simd<N2>: SimdValue + Copy,
-                  <Simd<N2> as SimdValue>::Element: SupersetOf<$t> + PartialEq, {
+        impl<N2> SubsetOf<AutoSimd<N2>> for $t
+            where AutoSimd<N2>: SimdValue + Copy,
+                  <AutoSimd<N2> as SimdValue>::Element: SupersetOf<$t> + PartialEq, {
             #[inline(always)]
-            fn to_superset(&self) -> Simd<N2> {
-                Simd::<N2>::splat(<Simd<N2> as SimdValue>::Element::from_subset(self))
+            fn to_superset(&self) -> AutoSimd<N2> {
+                AutoSimd::<N2>::splat(<AutoSimd<N2> as SimdValue>::Element::from_subset(self))
             }
 
             #[inline(always)]
-            fn from_superset_unchecked(element: &Simd<N2>) -> $t {
+            fn from_superset_unchecked(element: &AutoSimd<N2>) -> $t {
                 element.extract(0).to_subset_unchecked()
             }
 
             #[inline(always)]
-            fn is_in_subset(c: &Simd<N2>) -> bool {
+            fn is_in_subset(c: &AutoSimd<N2>) -> bool {
                 let elt0 = c.extract(0);
                 elt0.is_in_subset() &&
-                (1..Simd::<N2>::lanes()).all(|i| c.extract(i) == elt0)
+                (1..AutoSimd::<N2>::lanes()).all(|i| c.extract(i) == elt0)
             }
         }
     )*}
@@ -202,8 +219,40 @@ impl_scalar_subset_of_simd!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, 
 impl_scalar_subset_of_simd!(d128);
 
 macro_rules! impl_simd_value(
-    ($($t: ty, $elt: ty, $bool: ty, $($i: ident),*;)*) => ($(
-        impl fmt::Display for Simd<$t> {
+    ($($t: ty, $elt: ty, $lanes: expr, $bool: ty, $($i: ident),*;)*) => ($(
+        impl ArrTransform for AutoSimd<$t> {
+            #[inline(always)]
+            fn map(self, f: impl Fn(Self::Element) -> Self::Element) -> Self {
+                ident_to_value!();
+                Self([$(f(self.0[$i])),*])
+            }
+
+            #[inline(always)]
+            fn zip_map(self, other: Self, f: impl Fn(Self::Element, Self::Element) -> Self::Element) -> Self {
+                ident_to_value!();
+                Self([$(f(self.0[$i], other.0[$i])),*])
+            }
+
+            #[inline(always)]
+            fn zip_zip_map(self, b: Self, c: Self, f: impl Fn(Self::Element, Self::Element, Self::Element) -> Self::Element) -> Self {
+                ident_to_value!();
+                Self([$(f(self.0[$i], b.0[$i], c.0[$i])),*])
+            }
+
+            #[inline(always)]
+            fn map_bool(self, f: impl Fn(Self::Element) -> bool) -> Self::SimdBool {
+                ident_to_value!();
+                AutoSimd([$(f(self.0[$i])),*])
+            }
+
+            #[inline(always)]
+            fn zip_map_bool(self, other: Self, f: impl Fn(Self::Element, Self::Element) -> bool) -> Self::SimdBool {
+                ident_to_value!();
+                AutoSimd([$(f(self.0[$i], other.0[$i])),*])
+            }
+        }
+
+        impl fmt::Display for AutoSimd<$t> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 if Self::lanes() == 1 {
                     return self.extract(0).fmt(f);
@@ -219,90 +268,78 @@ macro_rules! impl_simd_value(
             }
         }
 
-        impl Simd<$t> {
-            #[inline]
+        impl AutoSimd<$t> {
             pub fn new($($i: $elt),*) -> Self {
-                Simd(<$t>::new($($i),*))
+                AutoSimd([$($i),*])
             }
         }
 
-        impl PrimitiveSimdValue for Simd<$t> {}
+        impl PrimitiveSimdValue for AutoSimd<$t> {}
 
-        impl SimdValue for Simd<$t> {
+        impl SimdValue for AutoSimd<$t> {
             type Element = $elt;
             type SimdBool = $bool;
 
             #[inline(always)]
             fn lanes() -> usize {
-                <$t>::lanes()
+                $lanes
             }
 
             #[inline(always)]
             fn splat(val: Self::Element) -> Self {
-                Simd(<$t>::splat(val))
+                AutoSimd([val; $lanes])
             }
 
             #[inline(always)]
             fn extract(&self, i: usize) -> Self::Element {
-                <$t>::extract(self.0, i)
+                self.0[i]
             }
 
             #[inline(always)]
             unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
-                <$t>::extract_unchecked(self.0, i)
+                *self.0.get_unchecked(i)
             }
 
             #[inline(always)]
             fn replace(&mut self, i: usize, val: Self::Element) {
-                *self = Simd(<$t>::replace(self.0, i, val))
+                self.0[i] = val
             }
 
             #[inline(always)]
             unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
-                *self = Simd(<$t>::replace_unchecked(self.0, i, val))
+                *self.0.get_unchecked_mut(i) = val
             }
 
             #[inline(always)]
             fn select(self, cond: Self::SimdBool, other: Self) -> Self {
-                Self(cond.0.select(self.0, other.0))
+                ident_to_value!();
+                Self([
+                    $(if cond.0[$i] { self.0[$i] } else { other.0[$i] }),*
+                ])
             }
         }
     )*)
 );
 
 macro_rules! impl_uint_simd(
-    ($($t: ty, $elt: ty, $bool: ty, $($i: ident),*;)*) => ($(
-        impl_simd_value!($t, $elt, $bool $(, $i)*;);
+    ($($t: ty, $elt: ty, $lanes: expr, $bool: ty, $($i: ident),*;)*) => ($(
+        impl_simd_value!($t, $elt, $lanes, $bool $(, $i)*;);
 
-        impl Simd<$t> {
-            /// Instantiates a new vector with the values of the `slice`.
-            ///
-            /// # Panics
-            ///
-            /// If `slice.len() < Self::lanes()`.
-            #[inline]
-            pub fn from_slice_unaligned(slice: &[$elt]) -> Self {
-                Simd(<$t>::from_slice_unaligned(slice))
-            }
-        }
-
-        impl From<[$elt; <$t>::lanes()]> for Simd<$t> {
+        impl From<[$elt; $lanes]> for AutoSimd<$t> {
             #[inline(always)]
-            fn from(vals: [$elt; <$t>::lanes()]) -> Self {
-                Simd(<$t>::from(vals))
+            fn from(vals: [$elt; $lanes]) -> Self {
+                AutoSimd(vals)
             }
         }
 
-        impl From<Simd<$t>> for [$elt; <$t>::lanes()] {
+        impl From<AutoSimd<$t>> for [$elt; $lanes] {
             #[inline(always)]
-            fn from(val: Simd<$t>) -> [$elt; <$t>::lanes()] {
-                let mut res = [<$elt>::zero(); <$t>::lanes()];
-                val.0.write_to_slice_unaligned(&mut res[..]);
-                res
+            fn from(val: AutoSimd<$t>) -> [$elt; $lanes] {
+                val.0
             }
         }
 
-        impl SubsetOf<Simd<$t>> for Simd<$t> {
+        impl SubsetOf<AutoSimd<$t>> for AutoSimd<$t> {
             #[inline(always)]
             fn to_superset(&self) -> Self {
                 *self
@@ -324,7 +361,7 @@ macro_rules! impl_uint_simd(
             }
         }
 
-        impl Num for Simd<$t> {
+        impl Num for AutoSimd<$t> {
             type FromStrRadixErr = <$elt as Num>::FromStrRadixErr;
 
             #[inline(always)]
@@ -333,7 +370,7 @@ macro_rules! impl_uint_simd(
             }
         }
 
-        impl FromPrimitive for Simd<$t> {
+        impl FromPrimitive for AutoSimd<$t> {
             #[inline(always)]
             fn from_i64(n: i64) -> Option<Self> {
                 <$elt>::from_i64(n).map(Self::splat)
@@ -396,10 +433,10 @@ macro_rules! impl_uint_simd(
         }
 
 
-        impl Zero for Simd<$t> {
+        impl Zero for AutoSimd<$t> {
             #[inline(always)]
             fn zero() -> Self {
-                Simd(<$t>::splat(<$elt>::zero()))
+                AutoSimd([<$elt>::zero(); $lanes])
             }
 
             #[inline(always)]
@@ -408,131 +445,131 @@ macro_rules! impl_uint_simd(
             }
         }
 
-        impl One for Simd<$t> {
+        impl One for AutoSimd<$t> {
             #[inline(always)]
             fn one() -> Self {
-                Simd(<$t>::splat(<$elt>::one()))
+                AutoSimd([<$elt>::one(); $lanes])
             }
         }
 
-        impl Add<Simd<$t>> for Simd<$t> {
+        impl Add<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
 
             #[inline(always)]
             fn add(self, rhs: Self) -> Self {
-                Self(self.0 + rhs.0)
+                self.zip_map(rhs, |x, y| x + y)
             }
         }
 
-        impl Sub<Simd<$t>> for Simd<$t> {
+        impl Sub<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
 
             #[inline(always)]
             fn sub(self, rhs: Self) -> Self {
-                Self(self.0 - rhs.0)
+                self.zip_map(rhs, |x, y| x - y)
             }
         }
 
-        impl Mul<Simd<$t>> for Simd<$t> {
+        impl Mul<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
 
             #[inline(always)]
             fn mul(self, rhs: Self) -> Self {
-                Self(self.0 * rhs.0)
+                self.zip_map(rhs, |x, y| x * y)
             }
         }
 
-        impl Div<Simd<$t>> for Simd<$t> {
+        impl Div<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
 
             #[inline(always)]
             fn div(self, rhs: Self) -> Self {
-                Self(self.0 / rhs.0)
+                self.zip_map(rhs, |x, y| x / y)
             }
         }
 
-        impl Rem<Simd<$t>> for Simd<$t> {
+        impl Rem<AutoSimd<$t>> for AutoSimd<$t> {
             type Output = Self;
 
             #[inline(always)]
             fn rem(self, rhs: Self) -> Self {
-                Self(self.0 % rhs.0)
+                self.zip_map(rhs, |x, y| x % y)
             }
         }
 
-        impl AddAssign<Simd<$t>> for Simd<$t> {
+        impl AddAssign<AutoSimd<$t>> for AutoSimd<$t> {
             #[inline(always)]
             fn add_assign(&mut self, rhs: Self) {
-                self.0 += rhs.0
+                *self = *self + rhs;
             }
         }
 
-        impl SubAssign<Simd<$t>> for Simd<$t> {
+        impl SubAssign<AutoSimd<$t>> for AutoSimd<$t> {
             #[inline(always)]
             fn sub_assign(&mut self, rhs: Self) {
-                self.0 -= rhs.0
+                *self = *self - rhs;
             }
         }
 
-        impl DivAssign<Simd<$t>> for Simd<$t> {
+        impl DivAssign<AutoSimd<$t>> for AutoSimd<$t> {
             #[inline(always)]
             fn div_assign(&mut self, rhs: Self) {
-                self.0 /= rhs.0
+                *self = *self / rhs;
             }
         }
 
-        impl MulAssign<Simd<$t>> for Simd<$t> {
+        impl MulAssign<AutoSimd<$t>> for AutoSimd<$t> {
             #[inline(always)]
             fn mul_assign(&mut self, rhs: Self) {
-                self.0 *= rhs.0
+                *self = *self * rhs;
             }
         }
 
-        impl RemAssign<Simd<$t>> for Simd<$t> {
+        impl RemAssign<AutoSimd<$t>> for AutoSimd<$t> {
             #[inline(always)]
             fn rem_assign(&mut self, rhs: Self) {
-                self.0 %= rhs.0
+                *self = *self % rhs;
             }
         }
 
-        impl SimdPartialOrd for Simd<$t> {
+        impl SimdPartialOrd for AutoSimd<$t> {
             #[inline(always)]
             fn simd_gt(self, other: Self) -> Self::SimdBool {
-                Simd(self.0.gt(other.0))
+                self.zip_map_bool(other, |x, y| x.simd_gt(y))
             }
 
             #[inline(always)]
             fn simd_lt(self, other: Self) -> Self::SimdBool {
-                Simd(self.0.lt(other.0))
+                self.zip_map_bool(other, |x, y| x.simd_lt(y))
             }
 
             #[inline(always)]
             fn simd_ge(self, other: Self) -> Self::SimdBool {
-                Simd(self.0.ge(other.0))
+                self.zip_map_bool(other, |x, y| x.simd_ge(y))
             }
 
             #[inline(always)]
             fn simd_le(self, other: Self) -> Self::SimdBool {
-                Simd(self.0.le(other.0))
+                self.zip_map_bool(other, |x, y| x.simd_le(y))
             }
 
             #[inline(always)]
             fn simd_eq(self, other: Self) -> Self::SimdBool {
-                Simd(self.0.eq(other.0))
+                self.zip_map_bool(other, |x, y| x.simd_eq(y))
             }
 
             #[inline(always)]
             fn simd_ne(self, other: Self) -> Self::SimdBool {
-                Simd(self.0.ne(other.0))
+                self.zip_map_bool(other, |x, y| x.simd_ne(y))
             }
 
             #[inline(always)]
             fn simd_max(self, other: Self) -> Self {
-                Simd(self.0.max(other.0))
+                self.zip_map(other, |x, y| x.simd_max(y))
             }
             #[inline(always)]
             fn simd_min(self, other: Self) -> Self {
-                Simd(self.0.min(other.0))
+                self.zip_map(other, |x, y| x.simd_min(y))
             }
 
             #[inline(always)]
@@ -542,102 +579,93 @@ macro_rules! impl_uint_simd(
 
             #[inline(always)]
             fn simd_horizontal_min(self) -> Self::Element {
-                self.0.min_element()
+                ident_to_value!();
+                self.0[0] $(.simd_min(self.0[$i]))*
             }
 
             #[inline(always)]
             fn simd_horizontal_max(self) -> Self::Element {
-                self.0.max_element()
+                ident_to_value!();
+                self.0[0] $(.simd_max(self.0[$i]))*
             }
         }
 
-//        impl MeetSemilattice for Simd<$t> {
+//        impl MeetSemilattice for AutoSimd<$t> {
 //            #[inline(always)]
 //            fn meet(&self, other: &Self) -> Self {
-//                Simd(self.0.min(other.0))
+//                AutoSimd(self.0.min(other.0))
 //            }
 //        }
 //
-//        impl JoinSemilattice for Simd<$t> {
+//        impl JoinSemilattice for AutoSimd<$t> {
 //            #[inline(always)]
 //            fn join(&self, other: &Self) -> Self {
-//                Simd(self.0.max(other.0))
+//                AutoSimd(self.0.max(other.0))
 //            }
 //        }
     )*)
 );
 
 macro_rules! impl_int_simd(
-    ($($t: ty, $elt: ty, $bool: ty, $($i: ident),*;)*) => ($(
-        impl_uint_simd!($t, $elt, $bool $(, $i)*;);
+    ($($t: ty, $elt: ty, $lanes: expr, $bool: ty, $($i: ident),*;)*) => ($(
+        impl_uint_simd!($t, $elt, $lanes, $bool $(, $i)*;);
 
-        impl Neg for Simd<$t> {
+        impl Neg for AutoSimd<$t> {
             type Output = Self;
 
             #[inline(always)]
             fn neg(self) -> Self {
-                Self(-self.0)
+                self.map(|x| -x)
             }
         }
     )*)
 );
 
 macro_rules! impl_float_simd(
-    ($($t: ty, $elt: ty, $int: ty, $bool: ty, $($i: ident),*;)*) => ($(
-        impl_int_simd!($t, $elt, $bool $(, $i)*;);
+    ($($t: ty, $elt: ty, $lanes: expr, $int: ty, $bool: ty, $($i: ident),*;)*) => ($(
+        impl_int_simd!($t, $elt, $lanes, $bool $(, $i)*;);
 
         // FIXME: this should be part of impl_int_simd
         // but those methods do not seem to be implemented
         // by packed_simd for integers.
-        impl SimdSigned for Simd<$t> {
+        impl SimdSigned for AutoSimd<$t> {
             #[inline(always)]
             fn simd_abs(&self) -> Self {
-                Simd(self.0.abs())
+                self.map(|x| x.simd_abs())
             }
 
             #[inline(always)]
             fn simd_abs_sub(&self, other: &Self) -> Self {
-                Simd((self.0 - other.0).max(Self::zero().0))
+                self.zip_map(*other, |x, y| x.simd_abs_sub(&y))
             }
 
             #[inline(always)]
             fn simd_signum(&self) -> Self {
-                // NOTE: is there a more efficient way of doing this?
-                let zero = Self::zero().0;
-                let one = Self::one().0;
-                let gt = self.0.gt(zero);
-                let lt = self.0.lt(zero);
-                Simd(lt.select(-one, gt.select(one, zero)))
+                self.map(|x| x.simd_signum())
             }
 
             #[inline(always)]
             fn is_simd_positive(&self) -> Self::SimdBool {
-                self.simd_gt(Self::zero())
+                self.map_bool(|x| x.is_simd_positive())
             }
 
             #[inline(always)]
             fn is_simd_negative(&self) -> Self::SimdBool {
-                self.simd_lt(Self::zero())
+                self.map_bool(|x| x.is_simd_negative())
             }
         }
 
-        impl Field for Simd<$t> {}
+        impl Field for AutoSimd<$t> {}
 
-        impl SimdRealField for Simd<$t> {
+        impl SimdRealField for AutoSimd<$t> {
             #[inline(always)]
             fn simd_atan2(self, other: Self) -> Self {
-                self.zip_map_lanes(other, |a, b| a.atan2(b))
+                self.zip_map(other, |x, y| x.simd_atan2(y))
             }
 
             #[inline(always)]
             fn simd_copysign(self, to: Self) -> Self {
-                use packed_simd::FromBits;
-                let sign_bits = <$int>::from_bits(<$t>::splat(-0.0));
-                let self_bits = <$int>::from_bits(self.0);
-                let to_bits = <$int>::from_bits(to.0);
-                let result =
-                    <$t>::from_bits((sign_bits & self_bits) | ((!sign_bits) & to_bits));
-                Simd(result)
+                self.zip_map(to, |x, y| x.simd_copysign(y))
             }
 
             #[inline(always)]
@@ -647,82 +675,82 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_pi() -> Self {
-                Simd(<$t>::PI)
+                Self::splat(<$elt>::simd_pi())
             }
 
             #[inline(always)]
             fn simd_two_pi() -> Self {
-                Simd(<$t>::PI + <$t>::PI)
+                Self::splat(<$elt>::simd_two_pi())
             }
 
             #[inline(always)]
             fn simd_frac_pi_2() -> Self {
-                Simd(<$t>::FRAC_PI_2)
+                Self::splat(<$elt>::simd_frac_pi_2())
             }
 
             #[inline(always)]
             fn simd_frac_pi_3() -> Self {
-                Simd(<$t>::FRAC_PI_3)
+                Self::splat(<$elt>::simd_frac_pi_3())
             }
 
             #[inline(always)]
             fn simd_frac_pi_4() -> Self {
-                Simd(<$t>::FRAC_PI_4)
+                Self::splat(<$elt>::simd_frac_pi_4())
             }
 
             #[inline(always)]
             fn simd_frac_pi_6() -> Self {
-                Simd(<$t>::FRAC_PI_6)
+                Self::splat(<$elt>::simd_frac_pi_6())
             }
 
             #[inline(always)]
             fn simd_frac_pi_8() -> Self {
-                Simd(<$t>::FRAC_PI_8)
+                Self::splat(<$elt>::simd_frac_pi_8())
             }
 
             #[inline(always)]
             fn simd_frac_1_pi() -> Self {
-                Simd(<$t>::FRAC_1_PI)
+                Self::splat(<$elt>::simd_frac_1_pi())
             }
 
             #[inline(always)]
             fn simd_frac_2_pi() -> Self {
-                Simd(<$t>::FRAC_2_PI)
+                Self::splat(<$elt>::simd_frac_2_pi())
             }
 
             #[inline(always)]
             fn simd_frac_2_sqrt_pi() -> Self {
-                Simd(<$t>::FRAC_2_SQRT_PI)
+                Self::splat(<$elt>::simd_frac_2_sqrt_pi())
             }
 
 
             #[inline(always)]
             fn simd_e() -> Self {
-                Simd(<$t>::E)
+                Self::splat(<$elt>::simd_e())
             }
 
             #[inline(always)]
             fn simd_log2_e() -> Self {
-                Simd(<$t>::LOG2_E)
+                Self::splat(<$elt>::simd_log2_e())
             }
 
             #[inline(always)]
             fn simd_log10_e() -> Self {
-                Simd(<$t>::LOG10_E)
+                Self::splat(<$elt>::simd_log10_e() )
             }
 
             #[inline(always)]
             fn simd_ln_2() -> Self {
-                Simd(<$t>::LN_2)
+                Self::splat(<$elt>::simd_ln_2())
             }
 
             #[inline(always)]
             fn simd_ln_10() -> Self {
-                Simd(<$t>::LN_10)
+                Self::splat(<$elt>::simd_ln_10())
             }
         }
 
-        impl SimdComplexField for Simd<$t> {
+        impl SimdComplexField for AutoSimd<$t> {
             type SimdRealField = Self;
 
             #[inline(always)]
@@ -742,190 +770,190 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_norm1(self) -> Self::SimdRealField {
-                Simd(self.0.abs())
+                self.map(|x| x.simd_norm1())
             }
 
             #[inline(always)]
             fn simd_modulus(self) -> Self::SimdRealField {
-                Simd(self.0.abs())
+                self.map(|x| x.simd_modulus())
             }
 
             #[inline(always)]
             fn simd_modulus_squared(self) -> Self::SimdRealField {
-                self * self
+                self.map(|x| x.simd_modulus_squared())
             }
 
             #[inline(always)]
             fn simd_argument(self) -> Self::SimdRealField {
-                self.map_lanes(|e| e.argument())
+                self.map(|x| x.simd_argument())
             }
 
             #[inline(always)]
             fn simd_to_exp(self) -> (Self::SimdRealField, Self) {
-                let ge = self.0.ge(Self::one().0);
-                let exp = ge.select(Self::one().0, -Self::one().0);
-                (Simd(self.0 * exp), Simd(exp))
+                let ge = self.simd_ge(Self::one());
+                let exp = Self::one().select(ge, -Self::one());
+                (self * exp, exp)
             }
 
             #[inline(always)]
             fn simd_recip(self) -> Self {
-                Self::one() / self
+                self.map(|x| x.simd_recip())
             }
 
             #[inline(always)]
             fn simd_conjugate(self) -> Self {
-                self
+                self.map(|x| x.simd_conjugate())
             }
 
             #[inline(always)]
             fn simd_scale(self, factor: Self::SimdRealField) -> Self {
-                Simd(self.0 * factor.0)
+                self.zip_map(factor, |x, y| x.simd_scale(y))
             }
 
             #[inline(always)]
             fn simd_unscale(self, factor: Self::SimdRealField) -> Self {
-                Simd(self.0 / factor.0)
+                self.zip_map(factor, |x, y| x.simd_unscale(y))
             }
 
             #[inline(always)]
             fn simd_floor(self) -> Self {
-                self.map_lanes(|e| e.floor())
+                self.map(|e| e.floor())
             }
 
             #[inline(always)]
             fn simd_ceil(self) -> Self {
-                self.map_lanes(|e| e.ceil())
+                self.map(|e| e.simd_ceil())
             }
 
             #[inline(always)]
             fn simd_round(self) -> Self {
-                self.map_lanes(|e| e.round())
+                self.map(|e| e.simd_round())
             }
 
             #[inline(always)]
             fn simd_trunc(self) -> Self {
-                self.map_lanes(|e| e.trunc())
+                self.map(|e| e.simd_trunc())
             }
 
             #[inline(always)]
             fn simd_fract(self) -> Self {
-                self.map_lanes(|e| e.fract())
+                self.map(|e| e.simd_fract())
             }
 
             #[inline(always)]
             fn simd_abs(self) -> Self {
-                Simd(self.0.abs())
+                self.map(|e| e.simd_abs())
             }
 
             #[inline(always)]
             fn simd_signum(self) -> Self {
-                self.map_lanes(|e| e.signum())
+                self.map(|e| e.simd_signum())
             }
 
             #[inline(always)]
             fn simd_mul_add(self, a: Self, b: Self) -> Self {
-                Simd(self.0.mul_add(a.0, b.0))
+                self.zip_zip_map(a, b, |x, y, z| x.simd_mul_add(y, z))
             }
 
             #[inline(always)]
             fn simd_powi(self, n: i32) -> Self {
-               Simd(self.0.powf(<$t>::splat(n as $elt)))
+                self.map(|e| e.simd_powi(n))
             }
 
             #[inline(always)]
             fn simd_powf(self, n: Self) -> Self {
-                Simd(self.0.powf(n.0))
+                self.zip_map(n, |x, y| x.simd_powf(y))
             }
 
             #[inline(always)]
             fn simd_powc(self, n: Self) -> Self {
-               Simd(self.0.powf(n.0))
+                self.zip_map(n, |x, y| x.simd_powc(y))
             }
 
             #[inline(always)]
             fn simd_sqrt(self) -> Self {
-                Simd(self.0.sqrt())
+                self.map(|x| x.simd_sqrt())
             }
 
             #[inline(always)]
             fn simd_exp(self) -> Self {
-                Simd(self.0.exp())
+                self.map(|x| x.simd_exp())
             }
 
             #[inline(always)]
             fn simd_exp2(self) -> Self {
-                self.map_lanes(|e| e.exp2())
+                self.map(|x| x.simd_exp2())
             }
 
 
             #[inline(always)]
             fn simd_exp_m1(self) -> Self {
-                self.map_lanes(|e| e.exp_m1())
+                self.map(|x| x.simd_exp_m1())
             }
 
             #[inline(always)]
             fn simd_ln_1p(self) -> Self {
-                self.map_lanes(|e| e.ln_1p())
+                self.map(|x| x.simd_ln_1p())
             }
 
             #[inline(always)]
             fn simd_ln(self) -> Self {
-                Simd(self.0.ln())
+                self.map(|x| x.simd_ln())
             }
 
             #[inline(always)]
             fn simd_log(self, base: Self) -> Self {
-                self.zip_map_lanes(base, |e, b| e.log(b))
+                self.zip_map(base, |x, y| x.simd_log(y))
             }
 
             #[inline(always)]
             fn simd_log2(self) -> Self {
-                self.map_lanes(|e| e.log2())
+                self.map(|x| x.simd_log2())
             }
 
             #[inline(always)]
             fn simd_log10(self) -> Self {
-                self.map_lanes(|e| e.log10())
+                self.map(|x| x.simd_log10())
             }
 
             #[inline(always)]
             fn simd_cbrt(self) -> Self {
-                self.map_lanes(|e| e.cbrt())
+                self.map(|x| x.simd_cbrt())
             }
 
             #[inline(always)]
             fn simd_hypot(self, other: Self) -> Self::SimdRealField {
-                self.zip_map_lanes(other, |e, o| e.hypot(o))
+                self.zip_map(other, |x, y| x.simd_hypot(y))
             }
 
             #[inline(always)]
             fn simd_sin(self) -> Self {
-                Simd(self.0.sin())
+                self.map(|x| x.simd_sin())
             }
 
             #[inline(always)]
             fn simd_cos(self) -> Self {
-                Simd(self.0.cos())
+                self.map(|x| x.simd_cos())
             }
 
             #[inline(always)]
             fn simd_tan(self) -> Self {
-                self.map_lanes(|e| e.tan())
+                self.map(|x| x.simd_tan())
             }
 
             #[inline(always)]
             fn simd_asin(self) -> Self {
-                self.map_lanes(|e| e.asin())
+                self.map(|x| x.simd_asin())
             }
 
             #[inline(always)]
             fn simd_acos(self) -> Self {
-                self.map_lanes(|e| e.acos())
+                self.map(|x| x.simd_acos())
             }
 
             #[inline(always)]
             fn simd_atan(self) -> Self {
-                self.map_lanes(|e| e.atan())
+                self.map(|x| x.simd_atan())
             }
 
             #[inline(always)]
@@ -945,40 +973,40 @@ macro_rules! impl_float_simd(
 //
             #[inline(always)]
             fn simd_sinh(self) -> Self {
-                self.map_lanes(|e| e.sinh())
+                self.map(|x| x.simd_sinh())
             }
 
             #[inline(always)]
             fn simd_cosh(self) -> Self {
-                self.map_lanes(|e| e.cosh())
+                self.map(|x| x.simd_cosh())
             }
 
             #[inline(always)]
             fn simd_tanh(self) -> Self {
-                self.map_lanes(|e| e.tanh())
+                self.map(|x| x.simd_tanh())
             }
 
             #[inline(always)]
             fn simd_asinh(self) -> Self {
-                self.map_lanes(|e| e.asinh())
+                self.map(|x| x.simd_asinh())
             }
 
             #[inline(always)]
             fn simd_acosh(self) -> Self {
-                self.map_lanes(|e| e.acosh())
+                self.map(|x| x.simd_acosh())
             }
 
             #[inline(always)]
             fn simd_atanh(self) -> Self {
-                self.map_lanes(|e| e.atanh())
+                self.map(|x| x.simd_atanh())
             }
         }
 
         // NOTE: most of the impls in there are copy-paste from the implementation of
         // ComplexField for num_complex::Complex. Unfortunately, we can't reuse the implementations
         // so easily.
-        impl SimdComplexField for num_complex::Complex<Simd<$t>> {
-            type SimdRealField = Simd<$t>;
+        impl SimdComplexField for num_complex::Complex<AutoSimd<$t>> {
+            type SimdRealField = AutoSimd<$t>;
 
             #[inline]
             fn from_simd_real(re: Self::SimdRealField) -> Self {
@@ -1072,8 +1100,8 @@ macro_rules! impl_float_simd(
 
             #[inline]
             fn simd_exp2(self) -> Self {
-                let _2 = Simd::<$t>::one() + Simd::<$t>::one();
-                num_complex::Complex::new(_2, Simd::<$t>::zero()).simd_powc(self)
+                let _2 = AutoSimd::<$t>::one() + AutoSimd::<$t>::one();
+                num_complex::Complex::new(_2, AutoSimd::<$t>::zero()).simd_powc(self)
             }
 
             #[inline]
@@ -1088,26 +1116,26 @@ macro_rules! impl_float_simd(
 
             #[inline]
             fn simd_log2(self) -> Self {
-                let _2 = Simd::<$t>::one() + Simd::<$t>::one();
+                let _2 = AutoSimd::<$t>::one() + AutoSimd::<$t>::one();
                 self.simd_log(_2)
             }
 
             #[inline]
             fn simd_log10(self) -> Self {
-                let _10 = Simd::<$t>::from_subset(&10.0f64);
+                let _10 = AutoSimd::<$t>::from_subset(&10.0f64);
                 self.simd_log(_10)
             }
 
             #[inline]
             fn simd_cbrt(self) -> Self {
-                let one_third = Simd::<$t>::from_subset(&(1.0 / 3.0));
+                let one_third = AutoSimd::<$t>::from_subset(&(1.0 / 3.0));
                 self.simd_powf(one_third)
             }
 
             #[inline]
             fn simd_powi(self, n: i32) -> Self {
                 // FIXME: is there a more accurate solution?
-                let n = Simd::<$t>::from_subset(&(n as f64));
+                let n = AutoSimd::<$t>::from_subset(&(n as f64));
                 self.simd_powf(n)
             }
 
@@ -1152,7 +1180,7 @@ macro_rules! impl_float_simd(
             #[inline]
             fn simd_sqrt(self) -> Self {
                 // formula: sqrt(r e^(it)) = sqrt(r) e^(it/2)
-                let two = Simd::<$t>::one() + Simd::<$t>::one();
+                let two = AutoSimd::<$t>::one() + AutoSimd::<$t>::one();
                 let (r, theta) = self.simd_to_polar();
                 simd_complex_from_polar(r.simd_sqrt(), theta / two)
             }
@@ -1173,7 +1201,7 @@ macro_rules! impl_float_simd(
 
             /// Returns the logarithm of `self` with respect to an arbitrary base.
             #[inline]
-            fn simd_log(self, base: Simd<$t>) -> Self {
+            fn simd_log(self, base: AutoSimd<$t>) -> Self {
                 // formula: log_y(x) = log_y(ρ e^(i θ))
                 // = log_y(ρ) + log_y(e^(i θ)) = log_y(ρ) + ln(e^(i θ)) / ln(y)
                 // = log_y(ρ) + i θ / ln(y)
@@ -1296,9 +1324,9 @@ macro_rules! impl_float_simd(
                 let two = one + one;
 
                 if self == i {
-                    return Self::new(Simd::<$t>::zero(), Simd::<$t>::one() / Simd::<$t>::zero());
+                    return Self::new(AutoSimd::<$t>::zero(), AutoSimd::<$t>::one() / AutoSimd::<$t>::zero());
                 } else if self == -i {
-                    return Self::new(Simd::<$t>::zero(), -Simd::<$t>::one() / Simd::<$t>::zero());
+                    return Self::new(AutoSimd::<$t>::zero(), -AutoSimd::<$t>::one() / AutoSimd::<$t>::zero());
                 }
 
                 ((one + i * self).simd_ln() - (one - i * self).simd_ln()) / (two * i)
@@ -1386,9 +1414,9 @@ macro_rules! impl_float_simd(
                 let one = Self::one();
                 let two = one + one;
                 if self == one {
-                    return Self::new(Simd::<$t>::one() / Simd::<$t>::zero(), Simd::<$t>::zero());
+                    return Self::new(AutoSimd::<$t>::one() / AutoSimd::<$t>::zero(), AutoSimd::<$t>::zero());
                 } else if self == -one {
-                    return Self::new(-Simd::<$t>::one() / Simd::<$t>::zero(), Simd::<$t>::zero());
+                    return Self::new(-AutoSimd::<$t>::one() / AutoSimd::<$t>::zero(), AutoSimd::<$t>::zero());
                 }
                 ((one + self).simd_ln() - (one - self).simd_ln()) / two
             }
@@ -1402,94 +1430,77 @@ fn simd_complex_from_polar<N: SimdRealField>(r: N, theta: N) -> num_complex::Com
 }
 
 impl_float_simd!(
-    packed_simd::f32x2, f32, packed_simd::i32x2, m32x2, _0, _1;
-    packed_simd::f32x4, f32, packed_simd::i32x4, m32x4, _0, _1, _2, _3;
-    packed_simd::f32x8, f32, packed_simd::i32x8, m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::f32x16, f32, packed_simd::i32x16, m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::f64x2, f64, packed_simd::i64x2, m64x2, _0, _1;
-    packed_simd::f64x4, f64, packed_simd::i64x4, m64x4, _0, _1, _2, _3;
-    packed_simd::f64x8, f64, packed_simd::i64x8, m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [f32; 2], f32, 2, [i32; 2], AutoBoolx2, _0, _1;
+    [f32; 4], f32, 4, [i32; 4], AutoBoolx4, _0, _1, _2, _3;
+    [f32; 8], f32, 8, [i32; 8], AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [f32; 16], f32, 16, [i32; 16], AutoBoolx16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [f64; 2], f64, 2, [i64; 2], AutoBoolx2, _0, _1;
+    [f64; 4], f64, 4, [i64; 4], AutoBoolx4, _0, _1, _2, _3;
+    [f64; 8], f64, 8, [i64; 8], AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
 impl_int_simd!(
-    packed_simd::i128x1, i128, m128x1, _0;
-    packed_simd::i128x2, i128, m128x2, _0, _1;
-    packed_simd::i128x4, i128, m128x4, _0, _1, _2, _3;
-    packed_simd::i16x2, i16, m16x2, _0, _1;
-    packed_simd::i16x4, i16, m16x4, _0, _1, _2, _3;
-    packed_simd::i16x8, i16, m16x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::i16x16, i16, m16x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::i16x32, i16, m16x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
-    packed_simd::i32x2, i32, m32x2, _0, _1;
-    packed_simd::i32x4, i32, m32x4, _0, _1, _2, _3;
-    packed_simd::i32x8, i32, m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::i32x16, i32, m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::i64x2, i64, m64x2, _0, _1;
-    packed_simd::i64x4, i64, m64x4, _0, _1, _2, _3;
-    packed_simd::i64x8, i64, m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::i8x2, i8, m8x2, _0, _1;
-    packed_simd::i8x4, i8, m8x4, _0, _1, _2, _3;
-    packed_simd::i8x8, i8, m8x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::i8x16, i8, m8x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::i8x32, i8, m8x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
-    packed_simd::i8x64, i8, m8x64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
-    packed_simd::isizex2, isize, msizex2, _0, _1;
-    packed_simd::isizex4, isize, msizex4, _0, _1, _2, _3;
-    packed_simd::isizex8, isize, msizex8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [i128; 1], i128, 1, AutoBoolx1, _0;
+    [i128; 2], i128, 2, AutoBoolx2, _0, _1;
+    [i128; 4], i128, 4, AutoBoolx4, _0, _1, _2, _3;
+    [i16; 2], i16, 2, AutoBoolx2, _0, _1;
+    [i16; 4], i16, 4, AutoBoolx4, _0, _1, _2, _3;
+    [i16; 8], i16, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [i16; 16], i16, 16, AutoBoolx16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [i16; 32], i16, 32, AutoBoolx32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    [i32; 2], i32, 2, AutoBoolx2, _0, _1;
+    [i32; 4], i32, 4, AutoBoolx4, _0, _1, _2, _3;
+    [i32; 8], i32, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [i32; 16], i32, 16, AutoBoolx16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [i64; 2], i64, 2, AutoBoolx2, _0, _1;
+    [i64; 4], i64, 4, AutoBoolx4, _0, _1, _2, _3;
+    [i64; 8], i64, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [i8; 2], i8, 2, AutoBoolx2, _0, _1;
+    [i8; 4], i8, 4, AutoBoolx4, _0, _1, _2, _3;
+    [i8; 8], i8, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [i8; 16], i8, 16, AutoBoolx16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [i8; 32], i8, 32, AutoBoolx32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    // [i8; 64], i8, 64, AutoBoolx64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
+    [isize; 2], isize, 2, AutoBoolx2, _0, _1;
+    [isize; 4], isize, 4, AutoBoolx4, _0, _1, _2, _3;
+    [isize; 8], isize, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
 impl_uint_simd!(
-    packed_simd::u128x1, u128, m128x1, _0;
-    packed_simd::u128x2, u128, m128x2, _0, _1;
-    packed_simd::u128x4, u128, m128x4, _0, _1, _2, _3;
-    packed_simd::u16x2, u16, m16x2, _0, _1;
-    packed_simd::u16x4, u16, m16x4, _0, _1, _2, _3;
-    packed_simd::u16x8, u16, m16x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::u16x16, u16, m16x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::u16x32, u16, m16x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
-    packed_simd::u32x2, u32, m32x2, _0, _1;
-    packed_simd::u32x4, u32, m32x4, _0, _1, _2, _3;
-    packed_simd::u32x8, u32, m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::u32x16, u32, m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::u64x2, u64, m64x2, _0, _1;
-    packed_simd::u64x4, u64, m64x4, _0, _1, _2, _3;
-    packed_simd::u64x8, u64, m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::u8x2, u8, m8x2, _0, _1;
-    packed_simd::u8x4, u8, m8x4, _0, _1, _2, _3;
-    packed_simd::u8x8, u8, m8x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::u8x16, u8, m8x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::u8x32, u8, m8x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
-    packed_simd::u8x64, u8, m8x64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
-    packed_simd::usizex2, usize, msizex2, _0, _1;
-    packed_simd::usizex4, usize, msizex4, _0, _1, _2, _3;
-    packed_simd::usizex8, usize, msizex8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [u128; 1], u128, 1, AutoBoolx1, _0;
+    [u128; 2], u128, 2, AutoBoolx2, _0, _1;
+    [u128; 4], u128, 4, AutoBoolx4, _0, _1, _2, _3;
+    [u16; 2], u16, 2, AutoBoolx2, _0, _1;
+    [u16; 4], u16, 4, AutoBoolx4, _0, _1, _2, _3;
+    [u16; 8], u16, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [u16; 16], u16, 16, AutoBoolx16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [u16; 32], u16, 32, AutoBoolx32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    [u32; 2], u32, 2, AutoBoolx2, _0, _1;
+    [u32; 4], u32, 4, AutoBoolx4, _0, _1, _2, _3;
+    [u32; 8], u32, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [u32; 16], u32, 16, AutoBoolx16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [u64; 2], u64, 2, AutoBoolx2, _0, _1;
+    [u64; 4], u64, 4, AutoBoolx4, _0, _1, _2, _3;
+    [u64; 8], u64, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [u8; 2], u8, 2, AutoBoolx2, _0, _1;
+    [u8; 4], u8, 4, AutoBoolx4, _0, _1, _2, _3;
+    [u8; 8], u8, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [u8; 16], u8, 16, AutoBoolx16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [u8; 32], u8, 32, AutoBoolx32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    // [u8; 64], u8, 64, AutoBoolx64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
+    [usize; 2], usize, 2, AutoBoolx2, _0, _1;
+    [usize; 4], usize, 4, AutoBoolx4, _0, _1, _2, _3;
+    [usize; 8], usize, 8, AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
 impl_bool_simd!(
-    packed_simd::m128x1, _0;
-    packed_simd::m128x2, _0, _1;
-    packed_simd::m128x4, _0, _1, _2, _3;
-    packed_simd::m16x2, _0, _1;
-    packed_simd::m16x4, _0, _1, _2, _3;
-    packed_simd::m16x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::m16x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::m16x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
-    packed_simd::m32x2, _0, _1;
-    packed_simd::m32x4, _0, _1, _2, _3;
-    packed_simd::m32x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::m32x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::m64x2, _0, _1;
-    packed_simd::m64x4, _0, _1, _2, _3;
-    packed_simd::m64x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::m8x2, _0, _1;
-    packed_simd::m8x4, _0, _1, _2, _3;
-    packed_simd::m8x8, _0, _1, _2, _3, _4, _5, _6, _7;
-    packed_simd::m8x16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
-    packed_simd::m8x32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
-    packed_simd::m8x64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
-    packed_simd::msizex2, _0, _1;
-    packed_simd::msizex4, _0, _1, _2, _3;
-    packed_simd::msizex8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [bool; 1], 1, _0;
+    [bool; 2], 2, _0, _1;
+    [bool; 4], 4, _0, _1, _2, _3;
+    [bool; 8], 8, _0, _1, _2, _3, _4, _5, _6, _7;
+    [bool; 16], 16, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15;
+    [bool; 32], 32, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31;
+    // [bool; 64], 64, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63;
 );
 
 //
@@ -1497,9 +1508,9 @@ impl_bool_simd!(
 //
 //macro_rules! impl_simd_complex_from(
 //    ($($t: ty, $elt: ty $(, $i: expr)*;)*) => ($(
-//        impl From<[num_complex::Complex<$elt>; <$t>::lanes()]> for num_complex::Complex<Simd<$t>> {
+//        impl From<[num_complex::Complex<$elt>; $lanes]> for num_complex::Complex<AutoSimd<$t>> {
 //            #[inline(always)]
-//            fn from(vals: [num_complex::Complex<$elt>; <$t>::lanes()]) -> Self {
+//            fn from(vals: [num_complex::Complex<$elt>; $lanes]) -> Self {
 //                num_complex::Complex {
 //                    re: <$t>::from([$(vals[$i].re),*]),
 //                    im: <$t>::from([$(vals[$i].im),*]),
@@ -1510,93 +1521,100 @@ impl_bool_simd!(
 //);
 //
 //impl_simd_complex_from!(
-//    packed_simd::f32x2, f32, 0, 1;
-//    packed_simd::f32x4, f32, 0, 1, 2, 3;
-//    packed_simd::f32x8, f32, 0, 1, 2, 3, 4, 5, 6, 7;
-//    packed_simd::f32x16, f32, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
+//    [f32; 2], f32, 0, 1;
+//    [f32; 4], f32, 0, 1, 2, 3;
+//    [f32; 8], f32, 0, 1, 2, 3, 4, 5, 6, 7;
+//    [f32; 16], f32, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
 //);
 
 //////////////////////////////////////////
 //               Aliases                //
 //////////////////////////////////////////
 
-pub type f32x2 = Simd<packed_simd::f32x2>;
-pub type f32x4 = Simd<packed_simd::f32x4>;
-pub type f32x8 = Simd<packed_simd::f32x8>;
-pub type f32x16 = Simd<packed_simd::f32x16>;
-pub type f64x2 = Simd<packed_simd::f64x2>;
-pub type f64x4 = Simd<packed_simd::f64x4>;
-pub type f64x8 = Simd<packed_simd::f64x8>;
-pub type i128x1 = Simd<packed_simd::i128x1>;
-pub type i128x2 = Simd<packed_simd::i128x2>;
-pub type i128x4 = Simd<packed_simd::i128x4>;
-pub type i16x2 = Simd<packed_simd::i16x2>;
-pub type i16x4 = Simd<packed_simd::i16x4>;
-pub type i16x8 = Simd<packed_simd::i16x8>;
-pub type i16x16 = Simd<packed_simd::i16x16>;
-pub type i16x32 = Simd<packed_simd::i16x32>;
-pub type i32x2 = Simd<packed_simd::i32x2>;
-pub type i32x4 = Simd<packed_simd::i32x4>;
-pub type i32x8 = Simd<packed_simd::i32x8>;
-pub type i32x16 = Simd<packed_simd::i32x16>;
-pub type i64x2 = Simd<packed_simd::i64x2>;
-pub type i64x4 = Simd<packed_simd::i64x4>;
-pub type i64x8 = Simd<packed_simd::i64x8>;
-pub type i8x2 = Simd<packed_simd::i8x2>;
-pub type i8x4 = Simd<packed_simd::i8x4>;
-pub type i8x8 = Simd<packed_simd::i8x8>;
-pub type i8x16 = Simd<packed_simd::i8x16>;
-pub type i8x32 = Simd<packed_simd::i8x32>;
-pub type i8x64 = Simd<packed_simd::i8x64>;
-pub type isizex2 = Simd<packed_simd::isizex2>;
-pub type isizex4 = Simd<packed_simd::isizex4>;
-pub type isizex8 = Simd<packed_simd::isizex8>;
-pub type u128x1 = Simd<packed_simd::u128x1>;
-pub type u128x2 = Simd<packed_simd::u128x2>;
-pub type u128x4 = Simd<packed_simd::u128x4>;
-pub type u16x2 = Simd<packed_simd::u16x2>;
-pub type u16x4 = Simd<packed_simd::u16x4>;
-pub type u16x8 = Simd<packed_simd::u16x8>;
-pub type u16x16 = Simd<packed_simd::u16x16>;
-pub type u16x32 = Simd<packed_simd::u16x32>;
-pub type u32x2 = Simd<packed_simd::u32x2>;
-pub type u32x4 = Simd<packed_simd::u32x4>;
-pub type u32x8 = Simd<packed_simd::u32x8>;
-pub type u32x16 = Simd<packed_simd::u32x16>;
-pub type u64x2 = Simd<packed_simd::u64x2>;
-pub type u64x4 = Simd<packed_simd::u64x4>;
-pub type u64x8 = Simd<packed_simd::u64x8>;
-pub type u8x2 = Simd<packed_simd::u8x2>;
-pub type u8x4 = Simd<packed_simd::u8x4>;
-pub type u8x8 = Simd<packed_simd::u8x8>;
-pub type u8x16 = Simd<packed_simd::u8x16>;
-pub type u8x32 = Simd<packed_simd::u8x32>;
-pub type u8x64 = Simd<packed_simd::u8x64>;
-pub type usizex2 = Simd<packed_simd::usizex2>;
-pub type usizex4 = Simd<packed_simd::usizex4>;
-pub type usizex8 = Simd<packed_simd::usizex8>;
+pub type AutoF32x2 = AutoSimd<[f32; 2]>;
+pub type AutoF32x4 = AutoSimd<[f32; 4]>;
+pub type AutoF32x8 = AutoSimd<[f32; 8]>;
+pub type AutoF32x16 = AutoSimd<[f32; 16]>;
+pub type AutoF64x2 = AutoSimd<[f64; 2]>;
+pub type AutoF64x4 = AutoSimd<[f64; 4]>;
+pub type AutoF64x8 = AutoSimd<[f64; 8]>;
+pub type AutoI128x1 = AutoSimd<[i128; 1]>;
+pub type AutoI128x2 = AutoSimd<[i128; 2]>;
+pub type AutoI128x4 = AutoSimd<[i128; 4]>;
+pub type AutoI16x2 = AutoSimd<[i16; 2]>;
+pub type AutoI16x4 = AutoSimd<[i16; 4]>;
+pub type AutoI16x8 = AutoSimd<[i16; 8]>;
+pub type AutoI16x16 = AutoSimd<[i16; 16]>;
+pub type AutoI16x32 = AutoSimd<[i16; 32]>;
+pub type AutoI32x2 = AutoSimd<[i32; 2]>;
+pub type AutoI32x4 = AutoSimd<[i32; 4]>;
+pub type AutoI32x8 = AutoSimd<[i32; 8]>;
+pub type AutoI32x16 = AutoSimd<[i32; 16]>;
+pub type AutoI64x2 = AutoSimd<[i64; 2]>;
+pub type AutoI64x4 = AutoSimd<[i64; 4]>;
+pub type AutoI64x8 = AutoSimd<[i64; 8]>;
+pub type AutoI8x2 = AutoSimd<[i8; 2]>;
+pub type AutoI8x4 = AutoSimd<[i8; 4]>;
+pub type AutoI8x8 = AutoSimd<[i8; 8]>;
+pub type AutoI8x16 = AutoSimd<[i8; 16]>;
+pub type AutoI8x32 = AutoSimd<[i8; 32]>;
+// pub type AutoI8x64 = AutoSimd<[i8; 64]>;
+pub type AutoIsizex2 = AutoSimd<[isize; 2]>;
+pub type AutoIsizex4 = AutoSimd<[isize; 4]>;
+pub type AutoIsizex8 = AutoSimd<[isize; 8]>;
+pub type AutoU128x1 = AutoSimd<[u128; 1]>;
+pub type AutoU128x2 = AutoSimd<[u128; 2]>;
+pub type AutoU128x4 = AutoSimd<[u128; 4]>;
+pub type AutoU16x2 = AutoSimd<[u16; 2]>;
+pub type AutoU16x4 = AutoSimd<[u16; 4]>;
+pub type AutoU16x8 = AutoSimd<[u16; 8]>;
+pub type AutoU16x16 = AutoSimd<[u16; 16]>;
+pub type AutoU16x32 = AutoSimd<[u16; 32]>;
+pub type AutoU32x2 = AutoSimd<[u32; 2]>;
+pub type AutoU32x4 = AutoSimd<[u32; 4]>;
+pub type AutoU32x8 = AutoSimd<[u32; 8]>;
+pub type AutoU32x16 = AutoSimd<[u32; 16]>;
+pub type AutoU64x2 = AutoSimd<[u64; 2]>;
+pub type AutoU64x4 = AutoSimd<[u64; 4]>;
+pub type AutoU64x8 = AutoSimd<[u64; 8]>;
+pub type AutoU8x2 = AutoSimd<[u8; 2]>;
+pub type AutoU8x4 = AutoSimd<[u8; 4]>;
+pub type AutoU8x8 = AutoSimd<[u8; 8]>;
+pub type AutoU8x16 = AutoSimd<[u8; 16]>;
+pub type AutoU8x32 = AutoSimd<[u8; 32]>;
+// pub type AutoU8x64 = AutoSimd<[u8; 64]>;
+pub type AutoUsizex2 = AutoSimd<[usize; 2]>;
+pub type AutoUsizex4 = AutoSimd<[usize; 4]>;
+pub type AutoUsizex8 = AutoSimd<[usize; 8]>;
 
-pub type m128x1 = Simd<packed_simd::m128x1>;
-pub type m128x2 = Simd<packed_simd::m128x2>;
-pub type m128x4 = Simd<packed_simd::m128x4>;
-pub type m16x16 = Simd<packed_simd::m16x16>;
-pub type m16x2 = Simd<packed_simd::m16x2>;
-pub type m16x32 = Simd<packed_simd::m16x32>;
-pub type m16x4 = Simd<packed_simd::m16x4>;
-pub type m16x8 = Simd<packed_simd::m16x8>;
-pub type m32x16 = Simd<packed_simd::m32x16>;
-pub type m32x2 = Simd<packed_simd::m32x2>;
-pub type m32x4 = Simd<packed_simd::m32x4>;
-pub type m32x8 = Simd<packed_simd::m32x8>;
-pub type m64x2 = Simd<packed_simd::m64x2>;
-pub type m64x4 = Simd<packed_simd::m64x4>;
-pub type m64x8 = Simd<packed_simd::m64x8>;
-pub type m8x16 = Simd<packed_simd::m8x16>;
-pub type m8x2 = Simd<packed_simd::m8x2>;
-pub type m8x32 = Simd<packed_simd::m8x32>;
-pub type m8x4 = Simd<packed_simd::m8x4>;
-pub type m8x64 = Simd<packed_simd::m8x64>;
-pub type m8x8 = Simd<packed_simd::m8x8>;
-pub type msizex2 = Simd<packed_simd::msizex2>;
-pub type msizex4 = Simd<packed_simd::msizex4>;
-pub type msizex8 = Simd<packed_simd::msizex8>;
+pub type AutoBoolx1 = AutoSimd<[bool; 1]>;
+pub type AutoBoolx16 = AutoSimd<[bool; 16]>;
+pub type AutoBoolx2 = AutoSimd<[bool; 2]>;
+pub type AutoBoolx32 = AutoSimd<[bool; 32]>;
+pub type AutoBoolx4 = AutoSimd<[bool; 4]>;
+// pub type AutoBoolx64 = AutoSimd<[bool; 64]>;
+pub type AutoBoolx8 = AutoSimd<[bool; 8]>;
+
+/*
+ * Helper trait to transform an array.
+ */
+trait ArrTransform: SimdValue {
+    fn map(self, f: impl Fn(Self::Element) -> Self::Element) -> Self;
+    fn zip_map(
+        self,
+        other: Self,
+        f: impl Fn(Self::Element, Self::Element) -> Self::Element,
+    ) -> Self;
+    fn zip_zip_map(
+        self,
+        b: Self,
+        c: Self,
+        f: impl Fn(Self::Element, Self::Element, Self::Element) -> Self::Element,
+    ) -> Self;
+    fn map_bool(self, f: impl Fn(Self::Element) -> bool) -> Self::SimdBool;
+    fn zip_map_bool(
+        self,
+        other: Self,
+        f: impl Fn(Self::Element, Self::Element) -> bool,
+    ) -> Self::SimdBool;
+}

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -657,6 +657,7 @@ macro_rules! impl_float_simd(
 
         impl Field for AutoSimd<$t> {}
 
+        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force"))]
         impl SimdRealField for AutoSimd<$t> {
             #[inline(always)]
             fn simd_atan2(self, other: Self) -> Self {
@@ -750,6 +751,7 @@ macro_rules! impl_float_simd(
             }
         }
 
+        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force"))]
         impl SimdComplexField for AutoSimd<$t> {
             type SimdRealField = Self;
 
@@ -1005,6 +1007,7 @@ macro_rules! impl_float_simd(
         // NOTE: most of the impls in there are copy-paste from the implementation of
         // ComplexField for num_complex::Complex. Unfortunately, we can't reuse the implementations
         // so easily.
+        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force"))]
         impl SimdComplexField for num_complex::Complex<AutoSimd<$t>> {
             type SimdRealField = AutoSimd<$t>;
 

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -1,5 +1,6 @@
 //! Traits implemented by SIMD types and non-SIMD types.
 
+pub use self::auto_simd_impl::*;
 #[cfg(feature = "packed_simd")]
 pub use self::packed_simd_impl::*;
 pub use self::simd_bool::SimdBool;
@@ -12,6 +13,7 @@ pub use self::simd_value::{PrimitiveSimdValue, SimdValue};
 #[cfg(feature = "wide")]
 pub use self::wide_simd_impl::{WideBoolF32x4, WideF32x4};
 
+mod auto_simd_impl;
 #[cfg(feature = "packed_simd")]
 mod packed_simd_impl;
 mod simd_bool;

--- a/src/simd/simd_bool.rs
+++ b/src/simd/simd_bool.rs
@@ -1,5 +1,5 @@
 use crate::simd::SimdValue;
-use std::ops::{BitAnd, BitOr, BitXor};
+use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 /// Lane-wise generalization of `bool` for SIMD booleans.
 ///
@@ -7,7 +7,11 @@ use std::ops::{BitAnd, BitOr, BitXor};
 /// It is designed to abstract the behavior of booleans so it can work with multi-lane boolean
 /// values in an AoSoA setting.
 pub trait SimdBool:
-    Copy + BitAnd<Self, Output = Self> + BitOr<Self, Output = Self> + BitXor<Self, Output = Self>
+    Copy
+    + BitAnd<Self, Output = Self>
+    + BitOr<Self, Output = Self>
+    + BitXor<Self, Output = Self>
+    + Not<Output = Self>
 {
     /// A bit mask representing the boolean state of each lanes of `self`.
     ///

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -13,8 +13,8 @@ use num::{FromPrimitive, Num, One, Zero};
 use std::{
     cmp::PartialEq,
     ops::{
-        Add, AddAssign, BitAnd, BitOr, BitXor, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign,
-        Sub, SubAssign,
+        Add, AddAssign, BitAnd, BitOr, BitXor, Div, DivAssign, Mul, MulAssign, Neg, Not, Rem,
+        RemAssign, Sub, SubAssign,
     },
 };
 
@@ -136,6 +136,15 @@ impl PartialEq for WideBoolF32x4 {
         let hack_a = wide::ConstUnionHack_f32x4 { wide_thing: self.0 };
         let hack_b = wide::ConstUnionHack_f32x4 { wide_thing: rhs.0 };
         unsafe { hack_a.u == hack_b.u }
+    }
+}
+
+impl Not for WideBoolF32x4 {
+    type Output = Self;
+
+    #[inline]
+    fn not(self) -> Self {
+        Self(!self.0)
     }
 }
 


### PR DESCRIPTION
This adds types implementing SIMD-related traits, but without relying on any SIMD intrinsic. This leaves auto-vectorization do all the job.

This is different from what, e.g., `wide` or `packed_simd` do because we have:
1. The guarantee that no explicit SIMD is performed, even on platforms that would support them.
2. The guarantee that we use the `libm` carte for all float operations when `libm_force` is enabled, even on platforms with `std` enabled (this can be needed for cross-platform determinism).