### PR TITLE
Fix compilation with no-std and libm feature. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
       - run:
           name: build
           command: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;
+      - run:
+          name: build --features libm
+          command: xargo build --verbose --no-default-features --features libm --target=x86_64-unknown-linux-gnu;
   build-nightly:
     executor: rust-nightly-executor
     steps:

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -819,7 +819,7 @@ macro_rules! impl_float_simd(
 
             #[inline(always)]
             fn simd_floor(self) -> Self {
-                self.map(|e| e.floor())
+                self.map(|e| e.simd_floor())
             }
 
             #[inline(always)]


### PR DESCRIPTION
This also adds to the CI a compilation with no-std and libm so we can detect this kind of regression earlier.
Fix #14