### PR TITLE
Swap the argument order of copysign.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+## Release v0.3.0
+This release includes a change that is not technically a breaking change because
+it won't cause existing code to not compile anymore. However it is an important
+semantic change to justify a major release:
+- The arguments of `copysign` are now swapped: `a.copysign(b)` will copy the sign of `b` into `a` (the previous
+  behavior copied the sign of `a` into `b`). This change was needed to align with the argument order used by
+  the standard library, thus avoiding hard-to-debug errors due to mismatching conventions.
+- The arguments of `simd_copysign` are now swapped too.
+
 ## Release v0.2.4
 - Make `Fixed.to_bits` and `Fixed::from_bits` const-fn.
 - Make our `Fixed` wrapper type `repr(transparent)`.

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -792,11 +792,11 @@ macro_rules! impl_fixed_type(
             }
 
             #[inline]
-            fn copysign(self, rhs: Self) -> Self {
-                if self >= Self::zero() {
-                    rhs.abs()
+            fn copysign(self, sign: Self) -> Self {
+                if sign >= Self::zero() {
+                    self.abs()
                 } else {
-                    -rhs.abs()
+                    -self.abs()
                 }
             }
 

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -67,9 +67,8 @@ macro_rules! impl_real(
             }
 
             #[inline(always)]
-            fn copysign(self, to: Self) -> Self {
-                let signbit = (-0.0 as $T).to_bits();
-                Self::from_bits((signbit & self.to_bits()) | ((!signbit) & to.to_bits()))
+            fn copysign(self, sign: Self) -> Self {
+                self.copysign(sign)
             }
 
             #[inline]

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -665,8 +665,8 @@ macro_rules! impl_float_simd(
             }
 
             #[inline(always)]
-            fn simd_copysign(self, to: Self) -> Self {
-                self.zip_map(to, |x, y| x.simd_copysign(y))
+            fn simd_copysign(self, sign: Self) -> Self {
+                self.zip_map(sign, |me, sgn| me.simd_copysign(sgn))
             }
 
             #[inline(always)]

--- a/src/simd/packed_simd_impl.rs
+++ b/src/simd/packed_simd_impl.rs
@@ -630,13 +630,13 @@ macro_rules! impl_float_simd(
             }
 
             #[inline(always)]
-            fn simd_copysign(self, to: Self) -> Self {
+            fn simd_copysign(self, sign: Self) -> Self {
                 use packed_simd::FromBits;
                 let sign_bits = <$int>::from_bits(<$t>::splat(-0.0));
+                let ref_bits = <$int>::from_bits(sign.0);
                 let self_bits = <$int>::from_bits(self.0);
-                let to_bits = <$int>::from_bits(to.0);
                 let result =
-                    <$t>::from_bits((sign_bits & self_bits) | ((!sign_bits) & to_bits));
+                    <$t>::from_bits((sign_bits & ref_bits) | ((!sign_bits) & self_bits));
                 Simd(result)
             }
 

--- a/src/simd/simd_real.rs
+++ b/src/simd/simd_real.rs
@@ -9,11 +9,11 @@ use crate::simd::{SimdComplexField, SimdPartialOrd, SimdSigned};
 pub trait SimdRealField:
     SimdPartialOrd + SimdSigned + SimdComplexField<SimdRealField = Self>
 {
-    /// Copies the sign of `self` to `to`.
+    /// Copies the sign of `sign` to `self`.
     ///
-    /// - Returns `to.simd_abs()` if `self` is positive or positive-zero.
-    /// - Returns `-to.simd_abs()` if `self` is negative or negative-zero.
-    fn simd_copysign(self, to: Self) -> Self;
+    /// - Returns `self.simd_abs()` if `sign` is positive or positive-zero.
+    /// - Returns `-self.simd_abs()` if `sign` is negative or negative-zero.
+    fn simd_copysign(self, sign: Self) -> Self;
     fn simd_atan2(self, other: Self) -> Self;
 
     fn simd_default_epsilon() -> Self;
@@ -47,8 +47,8 @@ impl<T: RealField> SimdRealField for T {
         Self::default_epsilon()
     }
     #[inline(always)]
-    fn simd_copysign(self, to: Self) -> Self {
-        self.copysign(to)
+    fn simd_copysign(self, sign: Self) -> Self {
+        self.copysign(sign)
     }
     #[inline(always)]
     fn simd_pi() -> Self {

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -638,9 +638,9 @@ impl SimdRealField for WideF32x4 {
     }
 
     #[inline(always)]
-    fn simd_copysign(self, to: Self) -> Self {
+    fn simd_copysign(self, sign: Self) -> Self {
         // WideF32x4(self.0.copysign(to.0))
-        WideF32x4((wide::f32x4::NEGATIVE_ZERO & self.0) | ((!wide::f32x4::NEGATIVE_ZERO) & to.0))
+        WideF32x4((wide::f32x4::NEGATIVE_ZERO & sign.0) | ((!wide::f32x4::NEGATIVE_ZERO) & self.0))
     }
 
     #[inline(always)]


### PR DESCRIPTION
This is technically not a breaking change because it won't cause existing code to not compile anymore. However it is an important
semantic change to justify a major release:
- The arguments of `copysign` are now swapped: `a.copysign(b)` will copy the sign of `b` into `a` (the previous
  behavior copied the sign of `a` into `b`). This change was needed to align with the argument order used by
  the standard library, thus avoiding hard-to-debug errors due to mismatching conventions.
- The arguments of `simd_copysign` are now swapped too.
