### PR TITLE
Adjust some trait bounds for RealField and ComplexField

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+## Release v0.7.0
+- Remove the `Bounded` requirement from `RealField`. Replace it by methods returning `Option<Self>` so that they can
+  still be implemented by unbounded types (by returning `None`).
+- The `ComplexField` trait derives  from `FromPrimitive` again. We can actually keep this because all its methods
+  return `Option<Self>`, meaning that it could be implemented by any type.
+
+
 ## Release v0.6.0
 - Replace all the `Copy` trait bounds by `Clone`, allowing more types to fulfill the requirements
   of `ComplexField` and `RealField`.

--- a/src/scalar/complex.rs
+++ b/src/scalar/complex.rs
@@ -1,4 +1,5 @@
 use num::{One, Signed, Zero};
+use num_traits::FromPrimitive;
 use std::any::Any;
 use std::fmt::{Debug, Display};
 use std::ops::Neg;
@@ -161,6 +162,7 @@ macro_rules! complex_trait_methods(
 pub trait ComplexField:
     SubsetOf<Self>
     + SupersetOf<f64>
+    + FromPrimitive
     + Field<Element = Self, SimdBool = bool>
     + Neg<Output = Self>
     + Clone

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -834,6 +834,16 @@ macro_rules! impl_fixed_type(
                 Self(cordic::atan2(self.0, other.0))
             }
 
+            #[inline]
+            fn min_value() -> Option<Self> {
+                Some(Bounded::min_value())
+            }
+
+            #[inline]
+            fn max_value() -> Option<Self> {
+                Some(Bounded::max_value())
+            }
+
             /// Archimedes' constant.
             #[inline]
             fn pi() -> Self {

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -1,4 +1,4 @@
-use num::{Bounded, Signed};
+use num::Signed;
 use std::{f32, f64};
 
 use approx::{RelativeEq, UlpsEq};
@@ -17,7 +17,6 @@ pub trait RealField:
     + RelativeEq<Epsilon = Self>
     + UlpsEq<Epsilon = Self>
     + Signed
-    + Bounded
     + PartialOrd
 {
     /// Is the sign of this real number positive?
@@ -34,6 +33,11 @@ pub trait RealField:
     fn min(self, other: Self) -> Self;
     fn clamp(self, min: Self, max: Self) -> Self;
     fn atan2(self, other: Self) -> Self;
+
+    /// The smallest finite positive value representable using this type.
+    fn min_value() -> Option<Self>;
+    /// The largest finite positive value representable using this type.
+    fn max_value() -> Option<Self>;
 
     fn pi() -> Self;
     fn two_pi() -> Self;
@@ -95,6 +99,19 @@ macro_rules! impl_real(
             #[inline]
             fn atan2(self, other: Self) -> Self {
                 $libm::atan2(self, other)
+            }
+
+
+            /// The smallest finite positive value representable using this type.
+            #[inline]
+            fn min_value() -> Option<Self> {
+                Some($M::MIN)
+            }
+
+            /// The largest finite positive value representable using this type.
+            #[inline]
+            fn max_value() -> Option<Self> {
+                Some($M::MAX)
             }
 
             /// Archimedes' constant.

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -8,7 +8,6 @@ use crate::simd::{
     PrimitiveSimdValue, SimdBool, SimdComplexField, SimdPartialOrd, SimdRealField, SimdSigned,
     SimdValue,
 };
-use approx::AbsDiffEq;
 #[cfg(feature = "decimal")]
 use decimal::d128;
 use num::{FromPrimitive, Num, One, Zero};

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -8,6 +8,7 @@ use crate::simd::{
     PrimitiveSimdValue, SimdBool, SimdComplexField, SimdPartialOrd, SimdRealField, SimdSigned,
     SimdValue,
 };
+use approx::AbsDiffEq;
 #[cfg(feature = "decimal")]
 use decimal::d128;
 use num::{FromPrimitive, Num, One, Zero};


### PR DESCRIPTION
- Remove the `Bounded` requirement from `RealField`. Replace it by methods returning `Option<Self>` so that they can
  still be implemented by unbounded types (by returning `None`). Fix #25 
- The `ComplexField` trait derives  from `FromPrimitive` again. We can actually keep this because all its methods
  return `Option<Self>`, meaning that it could be implemented by any type.