### PR TITLE
Add support for rust-CUDA

### DIFF
--- a/.github/workflows/simba-ci-build.yml
+++ b/.github/workflows/simba-ci-build.yml
@@ -51,3 +51,11 @@ jobs:
         run: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;
       - name: build x86_64-unknown-linux-gnu --features libm
         run: xargo build --verbose --no-default-features --features libm --target=x86_64-unknown-linux-gnu;
+  build-cuda:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Jimver/cuda-toolkit@v0.2.4
+      - uses: actions/checkout@v2
+      - run: rustup target add nvptx64-nvidia-cuda
+      - run: cargo build --no-default-features --features cuda
+      - run: cargo build --no-default-features --features cuda --target=nvptx64-nvidia-cuda

--- a/.github/workflows/simba-ci-build.yml
+++ b/.github/workflows/simba-ci-build.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           toolchain: nightly
           override: true
-          components: rustfmt
       - name: install xargo
         run: cp .github/Xargo.toml .; rustup component add rust-src; cargo install -f xargo;
       - name: build x86_64-unknown-linux-gnu
@@ -55,6 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Jimver/cuda-toolkit@v0.2.4
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
       - uses: actions/checkout@v2
       - run: rustup target add nvptx64-nvidia-cuda
       - run: cargo build --no-default-features --features cuda

--- a/.github/workflows/simba-ci-build.yml
+++ b/.github/workflows/simba-ci-build.yml
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Jimver/cuda-toolkit@v0.2.4
-      - name: Install latest nightly
+      - name: Install nightly-2021-10-17
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-10-17
           override: true
       - uses: actions/checkout@v2
       - run: rustup target add nvptx64-nvidia-cuda

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ std = ["wide/std"]
 partial_fixed_point_support = [ "fixed", "cordic" ]
 serde_serialize = [ "serde", "fixed/serde" ]
 libm = [ "num-traits/libm" ]
+cuda = [ "cuda_std" ]
 
 [dependencies]
 num-traits  = { version = "0.2.11", default-features = false }
@@ -34,6 +35,7 @@ paste       = "1.0"
 rand        = { version = "0.8", optional = true }
 serde       = { version = "1", default-features = false, optional = true }
 libm_force  = { package = "libm", version = "0.2", optional = true }
+cuda_std    = { version = "0.1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/scalar/complex.rs
+++ b/src/scalar/complex.rs
@@ -6,6 +6,13 @@ use std::ops::Neg;
 use std::{f32, f64};
 
 use crate::scalar::{Field, RealField, SubsetOf, SupersetOf};
+#[cfg(all(
+    any(target_arch = "nvptx", target_arch = "nvptx64"),
+    not(feature = "std"),
+    not(feature = "libm_force"),
+    feature = "cuda"
+))]
+use cuda_std::GpuFloat;
 #[cfg(all(not(feature = "std"), not(feature = "libm_force"), feature = "libm"))]
 use num::Float;
 //#[cfg(feature = "decimal")]
@@ -468,7 +475,13 @@ macro_rules! impl_complex(
     )*)
 );
 
-#[cfg(all(not(feature = "std"), not(feature = "libm_force"), feature = "libm"))]
+#[cfg(all(
+    not(target_arch = "nvptx"),
+    not(target_arch = "nvptx64"),
+    not(feature = "std"),
+    not(feature = "libm_force"),
+    feature = "libm"
+))]
 impl_complex!(
     f32, f32, Float;
     f64, f64, Float
@@ -478,6 +491,17 @@ impl_complex!(
 impl_complex!(
     f32,f32,f32;
     f64,f64,f64
+);
+
+#[cfg(all(
+    any(target_arch = "nvptx", target_arch = "nvptx64"),
+    not(feature = "std"),
+    not(feature = "libm_force"),
+    feature = "cuda"
+))]
+impl_complex!(
+    f32, f32, GpuFloat;
+    f64, f64, GpuFloat
 );
 
 #[cfg(feature = "libm_force")]

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -65,7 +65,7 @@ pub trait RealField:
 }
 
 macro_rules! impl_real(
-    ($($T:ty, $M:ident, $libm: ident);*) => ($(
+    ($($T:ty, $M:ident, $cpysgn_mod: ident, $atan_mod: ident);*) => ($(
         impl RealField for $T {
             #[inline]
             fn is_sign_positive(&self) -> bool {
@@ -79,7 +79,7 @@ macro_rules! impl_real(
 
             #[inline(always)]
             fn copysign(self, sign: Self) -> Self {
-                $libm::copysign(self, sign)
+                $cpysgn_mod::copysign(self, sign)
             }
 
             #[inline]
@@ -105,7 +105,7 @@ macro_rules! impl_real(
 
             #[inline]
             fn atan2(self, other: Self) -> Self {
-                $libm::atan2(self, other)
+                $atan_mod::atan2(self, other)
             }
 
 
@@ -222,9 +222,9 @@ macro_rules! impl_real(
     not(feature = "libm_force"),
     feature = "libm"
 ))]
-impl_real!(f32, f32, Float; f64, f64, Float);
+impl_real!(f32, f32, f32, Float; f64, f64, f64, Float);
 #[cfg(all(feature = "std", not(feature = "libm_force")))]
-impl_real!(f32, f32, f32; f64, f64, f64);
+impl_real!(f32, f32, f32, f32; f64, f64, f64, f64);
 #[cfg(all(
     any(target_arch = "nvptx", target_arch = "nvptx64"),
     not(feature = "std"),
@@ -232,11 +232,11 @@ impl_real!(f32, f32, f32; f64, f64, f64);
     feature = "cuda"
 ))]
 impl_real!(
-    f32, f32, GpuFloat;
-    f64, f64, GpuFloat
+    f32, f32, GpuFloat, GpuFloat;
+    f64, f64, GpuFloat, GpuFloat
 );
 #[cfg(feature = "libm_force")]
-impl_real!(f32, f32, libm_force_f32; f64, f64, libm_force);
+impl_real!(f32, f32, libm_force_f32, libm_force_f32; f64, f64, libm_force, libm_force);
 
 // We use this dummy module to remove the 'f' suffix at the end of
 // each libm functions to make our generic Real/ComplexField impl

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -657,7 +657,7 @@ macro_rules! impl_float_simd(
 
         impl Field for AutoSimd<$t> {}
 
-        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force"))]
+        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force", all(any(target_arch = "nvptx", target_arch = "nvptx64"), feature = "cuda")))]
         impl SimdRealField for AutoSimd<$t> {
             #[inline(always)]
             fn simd_atan2(self, other: Self) -> Self {
@@ -751,7 +751,7 @@ macro_rules! impl_float_simd(
             }
         }
 
-        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force"))]
+        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force", all(any(target_arch = "nvptx", target_arch = "nvptx64"), feature = "cuda")))]
         impl SimdComplexField for AutoSimd<$t> {
             type SimdRealField = Self;
 
@@ -1017,7 +1017,7 @@ macro_rules! impl_float_simd(
         // NOTE: most of the impls in there are copy-paste from the implementation of
         // ComplexField for num_complex::Complex. Unfortunately, we can't reuse the implementations
         // so easily.
-        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force"))]
+        #[cfg(any(feature = "std", feature = "libm", feature = "libm_force", all(any(target_arch = "nvptx", target_arch = "nvptx64"), feature = "cuda")))]
         impl SimdComplexField for num_complex::Complex<AutoSimd<$t>> {
             type SimdRealField = AutoSimd<$t>;
 


### PR DESCRIPTION
This adds CUDA supports by using the `cuda_std` crate to call the CUDA float intrinsics when targeting `nvptx`.
This is needed by https://github.com/dimforge/nalgebra/pull/1031