### PR TITLE
Modify impl_real call to build with libm

### DIFF
--- a/.github/workflows/simba-ci-build.yml
+++ b/.github/workflows/simba-ci-build.yml
@@ -65,3 +65,5 @@ jobs:
       - run: rustup target add nvptx64-nvidia-cuda
       - run: cargo build --no-default-features --features cuda
       - run: cargo build --no-default-features --features cuda --target=nvptx64-nvidia-cuda
+        env:
+          CUDA_ARCH: "350"

--- a/.github/workflows/simba-ci-build.yml
+++ b/.github/workflows/simba-ci-build.yml
@@ -22,6 +22,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build --no-default-feature
       run: cargo build --no-default-features;
+    - name: Build libm only
+      run: cargo build --no-default-features --features libm;
     - name: Build (default features)
       run: cargo build;
     - name: Build --features wide

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -222,7 +222,7 @@ macro_rules! impl_real(
     not(feature = "libm_force"),
     feature = "libm"
 ))]
-impl_real!(f32, f32, f32, Float; f64, f64, f64, Float);
+impl_real!(f32, f32, Float, Float; f64, f64, Float, Float);
 #[cfg(all(feature = "std", not(feature = "libm_force")))]
 impl_real!(f32, f32, f32, f32; f64, f64, f64, f64);
 #[cfg(all(


### PR DESCRIPTION
Changing `$cpysgn_mod` to `Float` is necessary to get the crate to build with only `libm` as features.

At least, this was a month ago.