### PR TITLE
Implement most of missing functionality for fixed point

### DIFF
--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -16,6 +16,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
+use std::iter::{Sum, Product};
 
 macro_rules! impl_fixed_type(
     ($($FixedI: ident, $Int: ident, $LeEqDim: ident, $LeEqDim1: ident, $LeEqDim2: ident, $LeEqDim3: ident, $LeEqDim4: ident;)*) => {$(
@@ -135,6 +136,42 @@ macro_rules! impl_fixed_type(
                 } else {
                     other
                 }
+            }
+        }
+
+        impl<Fract: $LeEqDim> Sum for $FixedI<Fract> {
+            fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+                iter.fold(
+                    Self::zero(),
+                    |a, b| a + b,
+                )
+            }
+        }
+
+        impl<'a, Fract: $LeEqDim> Sum<&'a $FixedI<Fract>> for $FixedI<Fract> {
+            fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+                iter.fold(
+                    Self::zero(),
+                    |a, b| a + *b,
+                )
+            }
+        }
+
+        impl<Fract: $LeEqDim> Product for $FixedI<Fract> {
+            fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
+                iter.fold(
+                    Self::one(),
+                    |a, b| a * b,
+                )
+            }
+        }
+
+        impl<'a, Fract: $LeEqDim> Product<&'a $FixedI<Fract> > for $FixedI<Fract>  {
+            fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+                iter.fold(
+                    Self::one(),
+                    |a, b| a * *b,
+                )
             }
         }
 

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -30,6 +30,10 @@ pub trait RealField:
     fn is_sign_positive(&self) -> bool;
     /// Is the sign of this real number negative?
     fn is_sign_negative(&self) -> bool;
+
+    // Returns true if the number is NaN.
+    fn is_nan(&self) -> bool;
+
     /// Copies the sign of `sign` to `self`.
     ///
     /// - Returns `self.simd_abs()` if `sign` is positive or positive-zero.
@@ -75,6 +79,11 @@ macro_rules! impl_real(
             #[inline]
             fn is_sign_negative(&self) -> bool {
                 $M::is_sign_negative(*self)
+            }
+
+            #[inline]
+            fn is_nan(&self) -> bool {
+                $M::is_nan(*self)
             }
 
             #[inline(always)]

--- a/src/simd/auto_simd_impl.rs
+++ b/src/simd/auto_simd_impl.rs
@@ -20,6 +20,9 @@ use std::{
     },
 };
 
+#[cfg(feature = "partial_fixed_point_support")]
+use crate::scalar::FixedI32F32;
+
 // This is a hack to allow use to reuse `_0` as integers or as identifier,
 // depending on whether or not `ident_to_value` has been called in scope.
 // This helps writing macros that define both `::new` and `From([T; lanes()])`.
@@ -229,6 +232,9 @@ macro_rules! impl_scalar_subset_of_simd(
 impl_scalar_subset_of_simd!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
 #[cfg(feature = "decimal")]
 impl_scalar_subset_of_simd!(d128);
+
+#[cfg(feature = "partial_fixed_point_support")]
+impl_scalar_subset_of_simd!(FixedI32F32);
 
 macro_rules! impl_simd_value(
     ($($t: ty, $elt: ty, $lanes: expr, $bool: ty, $($i: ident),*;)*) => ($(
@@ -1478,6 +1484,13 @@ impl_float_simd!(
     [f64; 8], f64, 8, [i64; 8], AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
 );
 
+#[cfg(feature = "partial_fixed_point_support")]
+impl_float_simd!(
+    [FixedI32F32; 2], FixedI32F32, 2, [i64; 2], AutoBoolx2, _0, _1;
+    [FixedI32F32; 4], FixedI32F32, 4, [i64; 4], AutoBoolx4, _0, _1, _2, _3;
+    [FixedI32F32; 8], FixedI32F32, 8, [i64; 8], AutoBoolx8, _0, _1, _2, _3, _4, _5, _6, _7;
+);
+
 impl_int_simd!(
     [i128; 1], i128, 1, AutoBoolx1, _0;
     [i128; 2], i128, 2, AutoBoolx2, _0, _1;
@@ -1633,6 +1646,15 @@ pub type AutoBoolx32 = AutoSimd<[bool; 32]>;
 pub type AutoBoolx4 = AutoSimd<[bool; 4]>;
 // pub type AutoBoolx64 = AutoSimd<[bool; 64]>;
 pub type AutoBoolx8 = AutoSimd<[bool; 8]>;
+
+#[cfg(feature = "partial_fixed_point_support")]
+pub type AutoFixedI32F32x2 = AutoSimd<[FixedI32F32; 2]>;
+
+#[cfg(feature = "partial_fixed_point_support")]
+pub type AutoFixedI32F32x4 = AutoSimd<[FixedI32F32; 4]>;
+
+#[cfg(feature = "partial_fixed_point_support")]
+pub type AutoFixedI32F32x8 = AutoSimd<[FixedI32F32; 8]>;
 
 /*
  * Helper trait to transform an array.


### PR DESCRIPTION
This PR implements missing functionality for fixed point numbers that is needed for parry to use fixed point numbers as reals instead of f32 or f64.

Some of the functionality is generalized and some of it is implemented only for FixedI32F32 fixed point number, as that is what I used to test this with parry.

I would like to get this completed for all fixed point numbers, so parry or other crates can use arbitrary fixed point numbers, but I am not sure how to continue (there is some `From` conversions in fixed_point.rs that I know how to generalize, but I am not sure how to `impl_float_simd!` for all fixed point numbers).

Could anyone point me in correct direction in order for me to complete this?