### PR TITLE
Update `packed_simd` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ num-traits  = { version = "0.2.11", default-features = false }
 approx      = { version = "0.5", default-features = false }
 decimal     = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.4", default-features = false }
-packed_simd = { package = "packed_simd_2", version = "0.3", features = [ "into_bits" ], optional = true }
+packed_simd = { version = "0.3.9", features = [ "into_bits" ], optional = true }
 wide        = { version = "0.7", default-features = false, optional = true }
 fixed       = { version = "1", optional = true }
 cordic      = { version = "0.1", optional = true }


### PR DESCRIPTION
`simba` does not compile under the latest nightly (2023-08-11) due to https://github.com/rust-lang/packed_simd/issues/356. It also seems like `packed_simd` is now the upstream crate again.