### PR TITLE
Allow direct conversions from f32 to RealField or ComplexField

### DIFF
--- a/src/scalar/complex.rs
+++ b/src/scalar/complex.rs
@@ -168,6 +168,7 @@ macro_rules! complex_trait_methods(
 #[allow(missing_docs)]
 pub trait ComplexField:
     SubsetOf<Self>
+    + SupersetOf<f32>
     + SupersetOf<f64>
     + FromPrimitive
     + Field<Element = Self, SimdBool = bool>

--- a/src/simd/simd_complex.rs
+++ b/src/simd/simd_complex.rs
@@ -1,8 +1,8 @@
 use num::{NumAssignOps, NumOps, Zero};
 use std::any::Any;
-use std::f64;
 use std::fmt::Debug;
 use std::ops::Neg;
+use std::{f32, f64};
 
 use crate::scalar::{ComplexField, Field, SubsetOf, SupersetOf};
 use crate::simd::{SimdRealField, SimdValue};
@@ -13,6 +13,7 @@ use crate::simd::{SimdRealField, SimdValue};
 #[allow(missing_docs)]
 pub trait SimdComplexField:
     SubsetOf<Self>
+    + SupersetOf<f32>
     + SupersetOf<f64>
     + Field
     + Clone


### PR DESCRIPTION
Fixes #54. This should help avoid surprises for users of crates like nalgebra when, for instance, casting `f32` matrices to `RealField` matrices.

One concern that is likely to block a merge of this PR is that anyone who implements `RealField` and `ComplexField` would need to implement an additional trait (`SupersetOf<f32>`). Given that both `f32` and `f64` have are in frequent use, this might be better long-term, but it would require a major version bump.

I'm not familiar enough with Rust to know whether it's possible to handle this in a backwards-compatible way. As far as I can tell, based on https://github.com/rust-lang/rust/issues/31844, it's not possible to create a default implementation. If I were to write the following
```rust
impl<T> SubsetOf<f32> for T where T: ComplexField {
    fn to_superset(&self) -> f32 {
        f64::from_subset(self) as f32
    }

    fn from_superset_unchecked(element: &f32) -> Self {
        f64::from_superset_unchecked(element) as f32
    }

    fn is_in_subset(element: &f32) -> bool {
        f64::is_in_subset(element)
    }
}
```
it would not compile because it conflicts with the more specific macro in `subset.rs` that effectively run `impl SubsetOf<f32> for f32` and `impl SubsetOf<32> for f64`.

The right answer might be to keep serde the way it is, although it may be good to document against potential pitfalls that could create. For instance, it hampers nalgebra's `cast` method for anyone trying to cast an `f32` matrix to a `RealField` matrix. However, if `RealField` is mostly meant to be used internally by dimforge crates, this might be a non-issue, in which case this PR should almost definitely be closed without merging.