### PR TITLE
Update CI

### DIFF
--- a/.github/Xargo.toml
+++ b/.github/Xargo.toml
@@ -1,5 +1,0 @@
-[target.x86_64-unknown-linux-gnu.dependencies]
-alloc = {}
-
-[target.thumbv7em-none-eabihf.dependencies]
-alloc = {}

--- a/.github/workflows/simba-ci-build.yml
+++ b/.github/workflows/simba-ci-build.yml
@@ -13,7 +13,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check formatting
         run: cargo fmt -- --check
   clippy:
@@ -21,24 +21,22 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
           components: clippy
       - name: Check formatting
         run: cargo clippy --all-features
   build-native:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: false
       - name: Build --no-default-feature
         run: cargo build --no-default-features;
       - name: Build libm only
@@ -52,22 +50,24 @@ jobs:
   build-wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: rustup target add wasm32-unknown-unknown
       - name: build
         run: cargo build --verbose --target wasm32-unknown-unknown;
   build-no-std:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
-          override: true
-      - name: install xargo
-        run: cp .github/Xargo.toml .; rustup component add rust-src; cargo install -f xargo;
-      - name: build x86_64-unknown-linux-gnu
-        run: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;
-      - name: build x86_64-unknown-linux-gnu --features libm
-        run: xargo build --verbose --no-default-features --features libm --target=x86_64-unknown-linux-gnu;
+          toolchain: stable
+          targets: "x86_64-unknown-none,thumbv7em-none-eabihf"
+      - name: build x86_64-unknown-none
+        run: cargo build --verbose --no-default-features --target=x86_64-unknown-none
+      - name: build x86_64-unknown-none --features libm
+        run: cargo build --verbose --no-default-features --features libm --target=x86_64-unknown-none
+      - name: build thumbv7em-none-eabihf
+        run: cargo build --verbose --no-default-features --target=thumbv7em-none-eabihf
+      - name: build thumbv7em-none-eabihf --features libm
+        run: cargo build --verbose --no-default-features --features libm --target=thumbv7em-none-eabihf


### PR DESCRIPTION
* Update to `actions/checkout` v4 from v2.
* Switch to `dtolnay/rust-toolchain`. The old `actions-rs` actions haven't been maintained in years.
* Stop using `xargo` for `no_std` builds and use `cargo` instead. Also, use better targets that have no std library available for them.