### PR TITLE
Update `rand` to 0.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 ## Unreleased
+- `rand` dependency updated to 0.9.
 - Add single-lanes portable-simd trait implementations.
 
 ## Release v0.9.1 (05 Sept. 2025)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ num-complex = { version = "0.4", default-features = false }
 wide = { version = "0.8.1", default-features = false, optional = true }
 fixed = { version = "1", optional = true }
 cordic = { version = "0.1", optional = true }
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9", optional = true }
 serde = { version = "1", default-features = false, optional = true }
 rkyv = { version = "0.7", optional = true }
 libm_force = { package = "libm", version = "0.2", optional = true }

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -76,19 +76,19 @@ macro_rules! impl_fixed_type (
         }
 
         #[cfg(feature = "rand")]
-        impl<Fract: $LeEqDim> rand::distributions::Distribution<$FixedI<Fract>> for rand::distributions::Standard {
+        impl<Fract: $LeEqDim> rand::distr::Distribution<$FixedI<Fract>> for rand::distr::StandardUniform {
             #[inline]
             fn sample<'a, G: rand::Rng + ?Sized>(&self, rng: &mut G) -> $FixedI<Fract> {
-                let bits = rng.gen();
+                let bits = rng.random();
                 $FixedI(fixed::$FixedI::from_bits(bits))
             }
         }
 
         #[cfg(feature = "rand")]
-        impl<Fract: $LeEqDim> rand::distributions::Distribution<$FixedI<Fract>> for rand::distributions::OpenClosed01 {
+        impl<Fract: $LeEqDim> rand::distr::Distribution<$FixedI<Fract>> for rand::distr::OpenClosed01 {
             #[inline]
             fn sample<'a, G: rand::Rng + ?Sized>(&self, rng: &mut G) -> $FixedI<Fract> {
-                let val: f64 = rng.gen();
+                let val: f64 = rng.random();
                 $FixedI(fixed::$FixedI::from_num(val))
             }
         }

--- a/src/simd/rand_impl.rs
+++ b/src/simd/rand_impl.rs
@@ -1,6 +1,3 @@
-use core::mem::{size_of, MaybeUninit};
-use core::slice;
-
 use crate::simd::*;
 
 // Given two token streams in the format `ignore_snd!([first_token_tree], [second])` will simply
@@ -231,24 +228,14 @@ impl_rand_portable_simd_xsize!(
 
 #[inline(always)]
 fn sample_isize<R: rand::Rng + ?Sized>(rng: &mut R) -> isize {
-    let mut result: MaybeUninit<isize> = MaybeUninit::uninit();
-    unsafe {
-        rng.fill_bytes(slice::from_raw_parts_mut(
-            result.as_mut_ptr().cast(),
-            size_of::<isize>(),
-        ));
-        result.assume_init()
-    }
+    let mut bytes = [0u8; _];
+    rng.fill_bytes(&mut bytes);
+    isize::from_le_bytes(bytes)
 }
 
 #[inline(always)]
 fn sample_usize<R: rand::Rng + ?Sized>(rng: &mut R) -> usize {
-    let mut result: MaybeUninit<usize> = MaybeUninit::uninit();
-    unsafe {
-        rng.fill_bytes(slice::from_raw_parts_mut(
-            result.as_mut_ptr().cast(),
-            size_of::<usize>(),
-        ));
-        result.assume_init()
-    }
+    let mut bytes = [0u8; _];
+    rng.fill_bytes(&mut bytes);
+    usize::from_le_bytes(bytes)
 }


### PR DESCRIPTION
Implementations of `Distribution<T> for StandardUniform` for all SIMD types containing `isize` and `usize` now generate random values using `fill_bytes()`.

Uniform distribution for `isize` and `usize` was removed from `rand` crate. See https://github.com/rust-random/rand/pull/1487 for details.

There is a new `UniformUsize` distribution, but it is limited to a maximum value under u32::MAX for portability across 32/64bits and for use as array indexes and lengths. Probably it is not suitable if a real uniform distribution is required.

Note that this is a breaking change. `nalgebra` already updated `rand` to `0.9` in https://github.com/dimforge/nalgebra/commit/2da148cc7e663897ed5faaa8dd7f3d5ff3048c05.