### PR TITLE
update wide version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ num-traits = { version = "0.2.11", default-features = false }
 approx = { version = "0.5", default-features = false }
 decimal = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.4", default-features = false }
-wide = { version = "0.7", default-features = false, optional = true }
+wide = { version = "0.8.1", default-features = false, optional = true }
 fixed = { version = "1", optional = true }
 cordic = { version = "0.1", optional = true }
 paste = "1.0"

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -625,32 +625,32 @@ macro_rules! impl_wide_f32 (
         impl SimdPartialOrd for $WideF32xX {
             #[inline(always)]
             fn simd_gt(self, other: Self) -> Self::SimdBool {
-                $WideBoolF32xX(self.0.cmp_gt(other.0))
+                $WideBoolF32xX(self.0.simd_gt(other.0))
             }
 
             #[inline(always)]
             fn simd_lt(self, other: Self) -> Self::SimdBool {
-                $WideBoolF32xX(self.0.cmp_lt(other.0))
+                $WideBoolF32xX(self.0.simd_lt(other.0))
             }
 
             #[inline(always)]
             fn simd_ge(self, other: Self) -> Self::SimdBool {
-                $WideBoolF32xX(self.0.cmp_ge(other.0))
+                $WideBoolF32xX(self.0.simd_ge(other.0))
             }
 
             #[inline(always)]
             fn simd_le(self, other: Self) -> Self::SimdBool {
-                $WideBoolF32xX(self.0.cmp_le(other.0))
+                $WideBoolF32xX(self.0.simd_le(other.0))
             }
 
             #[inline(always)]
             fn simd_eq(self, other: Self) -> Self::SimdBool {
-                $WideBoolF32xX(self.0.cmp_eq(other.0))
+                $WideBoolF32xX(self.0.simd_eq(other.0))
             }
 
             #[inline(always)]
             fn simd_ne(self, other: Self) -> Self::SimdBool {
-                $WideBoolF32xX(self.0.cmp_ne(other.0))
+                $WideBoolF32xX(self.0.simd_ne(other.0))
             }
 
             #[inline(always)]
@@ -862,7 +862,7 @@ macro_rules! impl_wide_f32 (
 
             #[inline(always)]
             fn simd_to_exp(self) -> (Self::SimdRealField, Self) {
-                let ge = self.0.cmp_ge(Self::one().0);
+                let ge = self.0.simd_ge(Self::one().0);
                 let exp = ge.blend(Self::one().0, -Self::one().0);
                 ($WideF32xX(self.0 * exp), $WideF32xX(exp))
             }


### PR DESCRIPTION
the `wide` crate had some breaking changes and updated to 0.8 [changelog](https://github.com/Lokathor/wide/blob/main/changelog.md#080), and so i'm putting in this update for you, since you're my biggest dependent on crates.io.

of course, since this crate seems to re-export the `wide` types, i think this would also be a breaking change in your own public interface.