### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
-## Unreleased
-- `rand` dependency updated to 0.9.
-- Add single-lanes portable-simd trait implementations.
+## Release v0.10.0 (24 May 2026)
+- Update the `rand` dependency to 0.10 (from 0.8). As a side-effect, the `Distribution<T> for StandardUniform`
+  implementations for SIMD types containing `isize`/`usize` now generate random values via `fill_bytes()`, because
+  `rand` 0.9 removed the uniform distribution for `isize`/`usize`. See [#76](https://github.com/dimforge/simba/pull/76).
+- Update the `wide` dependency to 1.0 (from 0.7). See [#78](https://github.com/dimforge/simba/pull/78).
+- Add the `f32x1`, `f64x1`, `i*x1`, `u*x1`, `m*x1` type aliases (and the corresponding trait implementations) when
+  the `portable_simd` feature is enabled. See [#67](https://github.com/dimforge/simba/pull/67).
+- Fix build with the `portable_simd` feature on recent `nightly` (adapt to `Mask::from_int`/`to_int` being renamed
+  to `from_simd`/`to_simd`). See [#79](https://github.com/dimforge/simba/pull/79).
+- Drop the `paste` build-time dependency; the macro-generated `ComplexField`/`SimdComplexField` method declarations
+  are now written out explicitly. See [#71](https://github.com/dimforge/simba/pull/71).
 
 ## Release v0.9.1 (05 Sept. 2025)
 - `into_arr`, `from_arr`, `map`, `zip_map` are now public on `WideF32x4`, `WideF32x8` and `WideF64x4`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ num-traits = { version = "0.2.11", default-features = false }
 approx = { version = "0.5", default-features = false }
 decimal = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.4", default-features = false }
-wide = { version = "0.8.1", default-features = false, optional = true }
+wide = { version = "1", default-features = false, optional = true }
 fixed = { version = "1", optional = true }
 cordic = { version = "0.1", optional = true }
-rand = { version = "0.9", optional = true }
+rand = { version = "0.10", optional = true }
 serde = { version = "1", default-features = false, optional = true }
 rkyv = { version = "0.7", optional = true }
 libm_force = { package = "libm", version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simba"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["sebcrozet <developer@crozet.re>"]
 description = "SIMD algebra for Rust"
 keywords = ["algebra", "simd", "math"]

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -16,6 +16,8 @@ use std::hash::{Hash, Hasher};
 use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
+#[cfg(feature = "rand")]
+use rand::RngExt;
 
 macro_rules! impl_fixed_type (
     ($($FixedI: ident, $Int: ident, $LeEqDim: ident, $LeEqDim1: ident, $LeEqDim2: ident, $LeEqDim3: ident, $LeEqDim4: ident;)*) => {$(

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -9,6 +9,8 @@ use fixed::types::extra::{
     U30, U31, U4, U5, U6, U60, U61, U62, U63, U7,
 };
 use num::{Bounded, FromPrimitive, Num, One, Signed, Zero};
+#[cfg(feature = "rand")]
+use rand::RngExt;
 #[cfg(feature = "serde_serialize")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
@@ -16,8 +18,6 @@ use std::hash::{Hash, Hasher};
 use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
-#[cfg(feature = "rand")]
-use rand::RngExt;
 
 macro_rules! impl_fixed_type (
     ($($FixedI: ident, $Int: ident, $LeEqDim: ident, $LeEqDim1: ident, $LeEqDim2: ident, $LeEqDim3: ident, $LeEqDim4: ident;)*) => {$(


### PR DESCRIPTION
## Release v0.10.0 (24 May 2026)
- Update the `rand` dependency to 0.10 (from 0.8). As a side-effect, the `Distribution<T> for StandardUniform`
  implementations for SIMD types containing `isize`/`usize` now generate random values via `fill_bytes()`, because
  `rand` 0.9 removed the uniform distribution for `isize`/`usize`. See [#76](https://github.com/dimforge/simba/pull/76).
- Update the `wide` dependency to 1.0 (from 0.7). See [#78](https://github.com/dimforge/simba/pull/78).
- Add the `f32x1`, `f64x1`, `i*x1`, `u*x1`, `m*x1` type aliases (and the corresponding trait implementations) when
  the `portable_simd` feature is enabled. See [#67](https://github.com/dimforge/simba/pull/67).
- Fix build with the `portable_simd` feature on recent `nightly` (adapt to `Mask::from_int`/`to_int` being renamed
  to `from_simd`/`to_simd`). See [#79](https://github.com/dimforge/simba/pull/79).
- Drop the `paste` build-time dependency; the macro-generated `ComplexField`/`SimdComplexField` method declarations
  are now written out explicitly. See [#71](https://github.com/dimforge/simba/pull/71).