### PR TITLE
Release v0.10.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-## Unreleased
+## Release v0.10.1 (02 August 2026)
 - Bump the minimum `wide` version to 1.6, and switch from the deprecated `blend`/`Cmp*` APIs to `select` and the
   inherent `simd_*` comparison methods.
 - The `WideF32xX`/`WideF64xX` math functions now go through `ComplexField`/`RealField` instead of the inherent `std`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simba"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["sebcrozet <developer@crozet.re>"]
 description = "SIMD algebra for Rust"
 keywords = ["algebra", "simd", "math"]


### PR DESCRIPTION
## Release v0.10.1 (02 August 2026)
- Bump the minimum `wide` version to 1.6, and switch from the deprecated `blend`/`Cmp*` APIs to `select` and the
  inherent `simd_*` comparison methods.
- The `WideF32xX`/`WideF64xX` math functions now go through `ComplexField`/`RealField` instead of the inherent `std`
  methods, so they honor the `libm_force` feature. Under `libm_force`, `simd_sin`, `simd_cos` and `simd_sin_cos` are
  computed per-lane with `libm` instead of `wide`'s SIMD polynomials.
- `SimdValue::splat` for the wide types no longer emits a `memset_pattern16` libc call.
