### PR TITLE
fix: downgrade wide to 1.5 + release v0.10.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+## Release v0.10.2 (07 August 2026)
+- Downgraded `wide` to 1.5 because its version 1.6 got yanked.
+
 ## Release v0.10.1 (02 August 2026)
 - Bump the minimum `wide` version to 1.6, and switch from the deprecated `blend`/`Cmp*` APIs to `select` and the
   inherent `simd_*` comparison methods.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ num-traits = { version = "0.2.11", default-features = false }
 approx = { version = "0.5", default-features = false }
 decimal = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.4", default-features = false }
-wide = { version = "1.6", default-features = false, optional = true }
+wide = { version = "1.5", default-features = false, optional = true }
 fixed = { version = "1", optional = true }
 cordic = { version = "0.1", optional = true }
 rand = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simba"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["sebcrozet <developer@crozet.re>"]
 description = "SIMD algebra for Rust"
 keywords = ["algebra", "simd", "math"]

--- a/src/scalar/real.rs
+++ b/src/scalar/real.rs
@@ -105,13 +105,13 @@ macro_rules! impl_real (
             /// The smallest finite positive value representable using this type.
             #[inline]
             fn min_value() -> Option<Self> {
-                Some($M::MIN)
+                Some(<$T>::MIN)
             }
 
             /// The largest finite positive value representable using this type.
             #[inline]
             fn max_value() -> Option<Self> {
-                Some($M::MAX)
+                Some(<$T>::MAX)
             }
 
             /// Archimedes' constant.

--- a/src/simd/wide_simd_impl.rs
+++ b/src/simd/wide_simd_impl.rs
@@ -194,7 +194,7 @@ macro_rules! impl_wide_f32 (
 
             #[inline(always)]
             fn select(self, cond: Self::SimdBool, other: Self) -> Self {
-                $WideF32xX(cond.0.select(self.0, other.0))
+                $WideF32xX(cond.0.blend(self.0, other.0))
             }
         }
 
@@ -240,7 +240,7 @@ macro_rules! impl_wide_f32 (
 
             #[inline(always)]
             fn select(self, cond: Self::SimdBool, other: Self) -> Self {
-                $WideBoolF32xX(cond.0.select(self.0, other.0))
+                $WideBoolF32xX(cond.0.blend(self.0, other.0))
             }
         }
 
@@ -864,7 +864,7 @@ macro_rules! impl_wide_f32 (
             #[inline(always)]
             fn simd_to_exp(self) -> (Self::SimdRealField, Self) {
                 let ge = self.0.simd_ge(Self::one().0);
-                let exp = ge.select(Self::one().0, -Self::one().0);
+                let exp = ge.blend(Self::one().0, -Self::one().0);
                 ($WideF32xX(self.0 * exp), $WideF32xX(exp))
             }
 


### PR DESCRIPTION
Downgraded `wide` to 1.5 because its version 1.6 got yanked.